### PR TITLE
ishell-skip-handler-registration-without-active-shell

### DIFF
--- a/cuiman/src/cuiman/api/ishell.py
+++ b/cuiman/src/cuiman/api/ishell.py
@@ -55,4 +55,7 @@ def _register_exception_handler() -> Callable[[Any, Any, Any, Any], None]:
 
 
 if has_ishell:
-    exception_handler = _register_exception_handler()
+    from IPython.core.interactiveshell import InteractiveShell
+
+    if InteractiveShell.initialized():
+        exception_handler = _register_exception_handler()

--- a/cuiman/tests/api/test_ishell.py
+++ b/cuiman/tests/api/test_ishell.py
@@ -56,6 +56,16 @@ class IShellTest(TestCase):
         self.assertEqual(None, result)
 
 
+def test_ishell_registers_handler_when_shell_already_initialized():
+    # Covers the module-level branch: has_ishell=True AND initialized()=True
+    InteractiveShell.instance()  # idempotent; ensures initialized() returns True
+    sys.modules.pop("cuiman.api.ishell", None)
+    import cuiman.api.ishell as ishell
+
+    assert ishell.exception_handler is not None
+    assert callable(ishell.exception_handler)
+
+
 def test_ishell_without_ipython(monkeypatch):
     # Remove any cached copy so the top-level code runs again
 

--- a/cuiman/tests/api/test_ishell.py
+++ b/cuiman/tests/api/test_ishell.py
@@ -9,23 +9,35 @@ from unittest.mock import patch
 from IPython.core.interactiveshell import InteractiveShell
 
 from cuiman import ClientError
-from cuiman.api.ishell import exception_handler, has_ishell
+from cuiman.api.ishell import has_ishell
 from gavicore.models import ApiError
 
 
 class IShellTest(TestCase):
+    handler = None
+
+    @classmethod
+    def setUpClass(cls):
+        from cuiman.api.ishell import _register_exception_handler
+
+        InteractiveShell.instance()  # ensure a shell exists before registering
+        # staticmethod prevents Python from binding the TestCase instance as `self`
+        # when the handler is accessed via self.handler — the handler's own `self`
+        # param expects an InteractiveShell, not a TestCase.
+        cls.handler = staticmethod(_register_exception_handler())
+
     def test_has_ishell_ok(self):
         self.assertTrue(has_ishell)
 
     def test_exception_handler_ok(self):
-        self.assertIsNotNone(exception_handler)
-        self.assertTrue(callable(exception_handler))
+        self.assertIsNotNone(self.handler)
+        self.assertTrue(callable(self.handler))
 
     def test_exception_handler_with_client_exception(self):
         exc = ClientError(
             "What the heck", ApiError(type="error", title="Don't worry, be happy")
         )
-        result = exception_handler(
+        result = self.handler(
             InteractiveShell.instance(),
             type(exc),
             exc,
@@ -35,7 +47,7 @@ class IShellTest(TestCase):
 
     def test_exception_handler_with_value_error(self):
         exc = ValueError("Too large")
-        result = exception_handler(
+        result = self.handler(
             InteractiveShell.instance(),
             type(exc),
             exc,

--- a/pixi.lock
+++ b/pixi.lock
@@ -5,8 +5,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -1666,6 +1664,7 @@ packages:
   - gavicore>=0.0.9
   - procodile>=0.0.9
   requires_python: '>=3.10'
+  editable: true
 - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
   sha256: 8f032b140ea4159806e4969a68b4a3c0a7cab1ad936eb958a2b5ffe5335e19bf
   md5: 54898d0f524c9dee622d44bbb081a8ab
@@ -3520,6 +3519,7 @@ packages:
   - httpx
   - gavicore>=0.0.9
   requires_python: '>=3.10'
+  editable: true
 - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
   sha256: bb47aec5338695ff8efbddbc669064a3b10fe34ad881fb8ad5d64fbfa6910ed1
   md5: 4c2a8fef270f6c69591889b93f9f55c1
@@ -3867,6 +3867,7 @@ packages:
   - procodile>=0.0.9
   - wraptile>=0.0.9
   requires_python: '>=3.10'
+  editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
   sha256: a5b51e491fec22bcc1765f5b2c8fff8a97428e9a5a7ee6730095fb9d091b0747
   md5: 057083b06ccf1c2778344b6dabace38b
@@ -4312,6 +4313,7 @@ packages:
   - pyyaml
   - typer
   requires_python: '>=3.10'
+  editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.6-h2b0a6b4_0.conda
   sha256: c5594497f0646e9079705b3199dbb2d5b13c48173cf110000fa1c8818e2b3e0c
   md5: 7892f39a39ed39591a89a28eba03e987
@@ -11075,11 +11077,13 @@ packages:
   - typer
   - gavicore>=0.0.9
   requires_python: '>=3.10'
+  editable: true
 - pypi: ./procodile-example
   name: procodile-example
   version: 0.0.0
   sha256: 0390557d504c40c82491e846771ed00a97238e926c9fed324825c9babe954378
   requires_python: '>=3.10'
+  editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.8.1-he0df7b0_0.conda
   sha256: dff6f355025b9a510d9093e29fd970fa1091e758b848c9dec814d96ae63a09ba
   md5: b23619e5e9009eaa070ead0342034027
@@ -14004,6 +14008,7 @@ packages:
   - gavicore>=0.0.9
   - procodile>=0.0.9
   requires_python: '>=3.10'
+  editable: true
 - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2026.4.0-pyhc364b38_0.conda
   sha256: 9f5f5905afea6e0188aa6887aed0809033143343a7af06983f4b390c2286d2d7
   md5: 099794df685f800c3f319ff4742dc1bb


### PR DESCRIPTION
[Description of PR]

fix: don't create InteractiveShell at import time — only register exception handler if shell is already running

Checklist (strike out non-applicable):

* [ ] Changes documented in `CHANGES.md`
* [ ] Related issue exists and is referred to in the PR description and `CHANGES.md`
* [ ] Added docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes/features documented in `docs/*`
* [ ] Unit-tests adapted/added for changes/features 
* [ ] Test coverage remains or increases (target 100%)
