### PR TITLE
Skip ishell handler registration without active shell

### DIFF
--- a/cuiman/src/cuiman/api/ishell.py
+++ b/cuiman/src/cuiman/api/ishell.py
@@ -55,4 +55,7 @@ def _register_exception_handler() -> Callable[[Any, Any, Any, Any], None]:
 
 
 if has_ishell:
-    exception_handler = _register_exception_handler()
+    from IPython.core.interactiveshell import InteractiveShell
+
+    if InteractiveShell.initialized():
+        exception_handler = _register_exception_handler()

--- a/cuiman/tests/api/test_ishell.py
+++ b/cuiman/tests/api/test_ishell.py
@@ -9,23 +9,35 @@ from unittest.mock import patch
 from IPython.core.interactiveshell import InteractiveShell
 
 from cuiman import ClientError
-from cuiman.api.ishell import exception_handler, has_ishell
+from cuiman.api.ishell import has_ishell
 from gavicore.models import ApiError
 
 
 class IShellTest(TestCase):
+    handler = None
+
+    @classmethod
+    def setUpClass(cls):
+        from cuiman.api.ishell import _register_exception_handler
+
+        InteractiveShell.instance()  # ensure a shell exists before registering
+        # staticmethod prevents Python from binding the TestCase instance as `self`
+        # when the handler is accessed via self.handler — the handler's own `self`
+        # param expects an InteractiveShell, not a TestCase.
+        cls.handler = staticmethod(_register_exception_handler())
+
     def test_has_ishell_ok(self):
         self.assertTrue(has_ishell)
 
     def test_exception_handler_ok(self):
-        self.assertIsNotNone(exception_handler)
-        self.assertTrue(callable(exception_handler))
+        self.assertIsNotNone(self.handler)
+        self.assertTrue(callable(self.handler))
 
     def test_exception_handler_with_client_exception(self):
         exc = ClientError(
             "What the heck", ApiError(type="error", title="Don't worry, be happy")
         )
-        result = exception_handler(
+        result = self.handler(
             InteractiveShell.instance(),
             type(exc),
             exc,
@@ -35,13 +47,23 @@ class IShellTest(TestCase):
 
     def test_exception_handler_with_value_error(self):
         exc = ValueError("Too large")
-        result = exception_handler(
+        result = self.handler(
             InteractiveShell.instance(),
             type(exc),
             exc,
             None,
         )
         self.assertEqual(None, result)
+
+
+def test_ishell_registers_handler_when_shell_already_initialized():
+    # Covers the module-level branch: has_ishell=True AND initialized()=True
+    InteractiveShell.instance()  # idempotent; ensures initialized() returns True
+    sys.modules.pop("cuiman.api.ishell", None)
+    import cuiman.api.ishell as ishell
+
+    assert ishell.exception_handler is not None
+    assert callable(ishell.exception_handler)
 
 
 def test_ishell_without_ipython(monkeypatch):


### PR DESCRIPTION
Skip ishell handler registration without active shell.

Fix: don't create InteractiveShell at import time — only register exception handler if shell is already running

FIY: @b-yogesh 

Checklist (strike out non-applicable):

* [ ] Changes documented in `CHANGES.md`
* [ ] Related issue exists and is referred to in the PR description and `CHANGES.md`
* [ ] Added docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes/features documented in `docs/*`
* [ ] Unit-tests adapted/added for changes/features 
* [ ] Test coverage remains or increases (target 100%)
