### PR TITLE
Fix regressions in new GUI generator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- Addressed various regressions in the new `gavicore` GUI generator. (#101)
 - Added missing API docs to `docs/cuiman/api.md` (deployed shortly after 0.1.0 release)
 - Fixed the PyPI release workflow (applied shortly after 0.1.0 release)
 

--- a/cuiman/tests/gui/panels/test_main_panel.py
+++ b/cuiman/tests/gui/panels/test_main_panel.py
@@ -20,6 +20,7 @@ from gavicore.models import (
     Schema,
 )
 from gavicore.ui.panel import PanelFieldFactoryRegistry
+from gavicore.ui.panel.widgets.bbox import BBoxEditor
 
 bbox_input = InputDescription(
     title="Bounding box",
@@ -67,6 +68,18 @@ class MainFormTest(TestCase):
     def test_with_bbox_input(self):
         main_panel = _create_main_panel({"bbox": bbox_input})
         self.assertIsInstance(main_panel.__panel__(), Panel)
+        inputs_field = main_panel.vm.inputs_field
+        self.assertIsNotNone(inputs_field)
+        assert inputs_field is not None
+        bbox_editor = inputs_field.view.inner_viewable.objects[0]
+        self.assertIsInstance(bbox_editor, BBoxEditor)
+
+        bbox_editor.value = [1.0, 2.0, 3.0, 4.0]
+
+        self.assertEqual(
+            {"bbox": [1.0, 2.0, 3.0, 4.0]},
+            inputs_field.view_model.value,
+        )
 
     def test_with_date_input(self):
         main_panel = _create_main_panel({"date": date_input})

--- a/cuiman/tests/gui/panels/test_main_panel.py
+++ b/cuiman/tests/gui/panels/test_main_panel.py
@@ -28,7 +28,9 @@ bbox_input = InputDescription(
         {
             "type": "array",
             "items": {"type": "number"},
-            "format": "bbox",
+            "x-ui-widget": "map",
+            "minItems": 4,
+            "maxItems": 4,
         }
     ),
 )

--- a/docs/cuiman/gui-generation.md
+++ b/docs/cuiman/gui-generation.md
@@ -230,9 +230,10 @@ A few tuple types are supported that generate special widgets instead of
 the default array editor:
 
 - **geographic bounding boxes**: item type `number` with `minItems: 4`, `maxItems: 4`, 
-  and `x-ui-widget: map` creates a special editor to enter the bounding box
-  using [](). It lets users draw a geometry whose bounding 
-  box will become the effective field value.
+  and `x-ui-widget: map` (or `format: bbox`) creates a special editor to enter the 
+  bounding box using an [ipyleaflet](https://ipyleaflet.readthedocs.io/) map. 
+  It lets users draw a geometry whose bounding box will become the effective field 
+  value.
 
 - **date(-time) ranges**: item type `string` with `minItems: 2`, `maxItems: 2` creates 
   a [date-time range picker](https://panel.holoviz.org/reference/widgets/DatetimeRangePicker.html) 

--- a/gavicore/src/gavicore/ui/field/meta.py
+++ b/gavicore/src/gavicore/ui/field/meta.py
@@ -574,9 +574,9 @@ def _get_initial_value(meta: FieldMeta) -> Any:
         case DataType.string:
             if schema.format == "date":
                 return datetime.date.today().isoformat()
-            # create string of length min_length
-            min_length = schema.minLength if schema.minLength is not None else 0
-            return "+" * min_length
+            if schema.format == "date-time":
+                return datetime.datetime.today().isoformat()
+            return ""
         case DataType.array:
             assert isinstance(meta.items, FieldMeta)
             # create array of length min_items

--- a/gavicore/src/gavicore/ui/field/meta.py
+++ b/gavicore/src/gavicore/ui/field/meta.py
@@ -556,7 +556,10 @@ def _is_valid_ui_prop(k, v) -> bool:
         return False
 
 
-def _get_initial_value(meta: FieldMeta) -> Any:
+def _get_initial_value(
+    meta: FieldMeta,
+    days_offset: int | None = None,
+) -> Any:
     schema = meta.schema_
     if schema.default is not None:
         return schema.default
@@ -572,17 +575,25 @@ def _get_initial_value(meta: FieldMeta) -> Any:
         case DataType.number:
             return float(_get_initial_number(schema))
         case DataType.string:
-            if schema.format == "date":
-                return datetime.date.today().isoformat()
-            if schema.format == "date-time":
-                return datetime.datetime.today().isoformat()
+            if schema.format in ("date", "date-time"):
+                date = (
+                    datetime.date.today()
+                    if schema.format == "date"
+                    else datetime.datetime.today()
+                )
+                if days_offset is not None:
+                    date -= datetime.timedelta(days=days_offset)
+                return date.isoformat()
             return ""
         case DataType.array:
             assert isinstance(meta.items, FieldMeta)
             # create array of length min_items
             min_items = schema.minItems if schema.minItems is not None else 0
             item_meta = meta.items
-            return [_get_initial_value(item_meta) for _i in range(min_items)]
+            return [
+                _get_initial_value(item_meta, days_offset=min_items - i - 1)
+                for i in range(min_items)
+            ]
         case DataType.object:
             assert isinstance(meta.properties, dict)
             # Note, we may also consider minProperties, additionalProperties
@@ -590,7 +601,7 @@ def _get_initial_value(meta: FieldMeta) -> Any:
             required = set(schema.required or [])
             properties = meta.properties
             return {
-                k: m.get_initial_value() for k, m in properties.items() if k in required
+                k: _get_initial_value(m) for k, m in properties.items() if k in required
             }
         case _:
             # TODO: handle other cases here: oneOf, anyOf, allOf

--- a/gavicore/src/gavicore/ui/panel/factory.py
+++ b/gavicore/src/gavicore/ui/panel/factory.py
@@ -26,7 +26,6 @@ from gavicore.util.text import ArrayTextConverter, TextConverter
 
 from .field import PanelField
 from .widgets.array import ArrayEditor, ArrayWidget
-from .widgets.bbox import BBoxEditor
 from .widgets.labeled import LabeledWidget
 from .widgets.nullable import NullableWidget
 
@@ -266,6 +265,8 @@ class DefaultPanelFieldFactory(PanelFieldFactoryBase):
             and min_items == 4
             and max_items == 4
         ):
+            from .widgets.bbox import BBoxEditor
+
             return PanelField(
                 view_model,
                 BBoxEditor(name=ctx.label, value=view_model.value),

--- a/gavicore/src/gavicore/ui/panel/factory.py
+++ b/gavicore/src/gavicore/ui/panel/factory.py
@@ -162,7 +162,7 @@ class DefaultPanelFieldFactory(PanelFieldFactoryBase):
     def create_string_field(self, ctx: FieldContext) -> PanelField:
         view_model = ctx.vm.primitive()
         value = view_model.value
-        label = view_model.meta.label
+        label = ctx.label
         enum = view_model.meta.enum
         description = view_model.meta.description
         placeholder = view_model.meta.placeholder or ""

--- a/gavicore/src/gavicore/ui/panel/factory.py
+++ b/gavicore/src/gavicore/ui/panel/factory.py
@@ -62,7 +62,7 @@ class DefaultPanelFieldFactory(PanelFieldFactoryBase):
         return PanelField(
             view_model,
             NullableWidget(
-                name=ctx.name,
+                name=ctx.label,
                 value=ctx.initial_value,
                 inner_widget=non_nullable_field.view,
             ),

--- a/gavicore/src/gavicore/ui/panel/factory.py
+++ b/gavicore/src/gavicore/ui/panel/factory.py
@@ -261,13 +261,15 @@ class DefaultPanelFieldFactory(PanelFieldFactoryBase):
         view_model = ctx.vm.array()
         json_codec: JsonCodec
 
-        if (
-            item_type == DataType.number
-            and (format_ == "bbox" or widget_hint == "map")
+        if item_type == DataType.number and (
+            (format_ == "bbox" or widget_hint == "map")
             and min_items == 4
             and max_items == 4
         ):
-            return PanelField(view_model, BBoxEditor())
+            return PanelField(
+                view_model,
+                BBoxEditor(name=ctx.label, value=view_model.value),
+            )
 
         if (
             item_type == DataType.string

--- a/gavicore/src/gavicore/ui/panel/widgets/array.py
+++ b/gavicore/src/gavicore/ui/panel/widgets/array.py
@@ -33,6 +33,7 @@ class ArrayWidget(pn.widgets.WidgetBase, pn.custom.PyComponent):
         self.value = value
         self._array_converter = array_converter
         self._separator = sep_
+        self._updating_from_text = False
 
         initial_text = self._array_converter.format(value, sep=sep_)
         sep_text = "space or newline" if not sep_ or not sep_.strip() else f"{sep_!r}"
@@ -41,11 +42,12 @@ class ArrayWidget(pn.widgets.WidgetBase, pn.custom.PyComponent):
             value=initial_text,
             cols=16,
             rows=1,
-            name=name,
+            name=name or "",
             placeholder=help_text,
             description=description or help_text,
         )
         self._text.param.watch(self._on_text_value_change, "value")
+        self.param.watch(self._on_value_change, "value")
 
     def _on_text_value_change(self, event):
         assert isinstance(event.new, str)
@@ -53,9 +55,21 @@ class ArrayWidget(pn.widgets.WidgetBase, pn.custom.PyComponent):
         try:
             value = self._array_converter.parse(text, sep=self._separator)
             if value != self.value:
-                self.value = value
+                self._updating_from_text = True
+                try:
+                    self.value = value
+                finally:
+                    self._updating_from_text = False
         except ValueError as e:
             self.error_message = f"{e}."
+
+    def _on_value_change(self, event):
+        if self._updating_from_text:
+            return
+
+        text = self._array_converter.format(event.new, sep=self._separator)
+        if text != self._text.value:
+            self._text.value = text
 
     def __panel__(self):
         return pn.Column(self._text)
@@ -99,6 +113,7 @@ class ArrayEditor(pn.widgets.WidgetBase, pn.custom.PyComponent):
         else:
             panel = pn.Column(self._items_box, self._add_row)
         self._panel = panel
+        self._updating_from_item_editor = False
         self._update_item_rows()
         self.param.watch(self._on_value_change, "value")
 
@@ -106,6 +121,8 @@ class ArrayEditor(pn.widgets.WidgetBase, pn.custom.PyComponent):
         self.value = self.value + [self._item_value_factory()]
 
     def _on_value_change(self, _e):
+        if self._updating_from_item_editor:
+            return
         self._update_item_rows()
 
     def _update_item_rows(self):
@@ -133,7 +150,11 @@ class ArrayEditor(pn.widgets.WidgetBase, pn.custom.PyComponent):
         def on_item_value_change(e):
             v = list(self.value)
             v[index] = e.new
-            self.value = v
+            self._updating_from_item_editor = True
+            try:
+                self.value = v
+            finally:
+                self._updating_from_item_editor = False
 
         item_editor = self._item_editor_factory(index, value)
         item_editor.param.watch(on_item_value_change, "value")

--- a/gavicore/src/gavicore/ui/panel/widgets/array.py
+++ b/gavicore/src/gavicore/ui/panel/widgets/array.py
@@ -115,7 +115,7 @@ class ArrayEditor(pn.widgets.WidgetBase, pn.custom.PyComponent):
     def _render_item_rows(self):
         return [self._render_item_row(i, v) for i, v in enumerate(self.value)]
 
-    def _render_item_row(self, index, value):
+    def _render_item_row(self, index, value) -> pn.Row:
         def on_delete_item(_event):
             v = list(self.value)
             del v[index]
@@ -129,7 +129,7 @@ class ArrayEditor(pn.widgets.WidgetBase, pn.custom.PyComponent):
             styles={"gap": "0.5em"},
         )
 
-    def _render_item_editor(self, index, value):
+    def _render_item_editor(self, index, value) -> pn.widgets.WidgetBase:
         def on_item_value_change(e):
             v = list(self.value)
             v[index] = e.new

--- a/gavicore/src/gavicore/ui/panel/widgets/bbox.py
+++ b/gavicore/src/gavicore/ui/panel/widgets/bbox.py
@@ -6,9 +6,6 @@ from typing import Any
 
 import panel as pn
 import param
-from ipyleaflet import DrawControl, GeoJSON, Map
-
-pn.extension("ipywidgets")
 
 BBox = list[float]
 
@@ -24,7 +21,10 @@ class BBoxEditor(pn.widgets.WidgetBase, pn.custom.PyComponent):
         zoom: int = 2,
         **params,
     ):
+        pn.extension("ipywidgets")
         super().__init__(**params)
+
+        from ipyleaflet import DrawControl, Map
 
         # --- draw control
         enabled_tool: dict[str, Any] = {"shapeOptions": {"color": "#0000FF"}}
@@ -79,6 +79,8 @@ class BBoxEditor(pn.widgets.WidgetBase, pn.custom.PyComponent):
                 self._map.remove(layer)
 
         if geo_json is not None:
+            from ipyleaflet import GeoJSON
+
             self._map.add(GeoJSON(name="user", data=geo_json))
 
     @staticmethod
@@ -108,7 +110,7 @@ class BBoxEditor(pn.widgets.WidgetBase, pn.custom.PyComponent):
         }
 
     # --- map → value
-    def _handle_draw(self, target: DrawControl, action: str, geo_json: dict):
+    def _handle_draw(self, target: Any, action: str, geo_json: dict):
         if action != "created":
             return
 

--- a/gavicore/src/gavicore/ui/panel/widgets/bbox.py
+++ b/gavicore/src/gavicore/ui/panel/widgets/bbox.py
@@ -8,7 +8,7 @@ import panel as pn
 import param
 from ipyleaflet import DrawControl, GeoJSON, Map
 
-pn.extension()
+pn.extension("ipywidgets")
 
 BBox = list[float]
 
@@ -41,7 +41,7 @@ class BBoxEditor(pn.widgets.WidgetBase, pn.custom.PyComponent):
         self._map = Map(center=center, zoom=zoom, scroll_wheel_zoom=True)
         self._map.add(draw_control)
 
-        map_widget = pn.pane.IPyWidget(self._map, width=400)
+        map_widget = pn.pane.IPyWidget(self._map, width=400, height=400)
 
         # --- value display
         # TODO: replace by text box to let user enter the 4 coordinates
@@ -49,12 +49,14 @@ class BBoxEditor(pn.widgets.WidgetBase, pn.custom.PyComponent):
 
         def on_value_change(e):
             self._update_display(e.new)
+            self._update_bbox_layer(e.new)
 
         # react to value changes
         self.param.watch(on_value_change, "value")
 
-        # initial display
+        # initial display and map layer
         self._update_display(self.value)
+        self._update_bbox_layer(self.value)
 
         # layout
         self._panel = pn.Column(map_widget, self._value_display)
@@ -67,6 +69,43 @@ class BBoxEditor(pn.widgets.WidgetBase, pn.custom.PyComponent):
 
     def _update_display(self, value):
         self._value_display.value = f"Selected bbox: {value}"
+
+    def _update_bbox_layer(self, value: Any):
+        self._replace_user_layer(self._bbox_to_geo_json(value))
+
+    def _replace_user_layer(self, geo_json: dict | None):
+        for layer in list(self._map.layers):
+            if getattr(layer, "name", None) == "user":
+                self._map.remove(layer)
+
+        if geo_json is not None:
+            self._map.add(GeoJSON(name="user", data=geo_json))
+
+    @staticmethod
+    def _bbox_to_geo_json(value: Any) -> dict | None:
+        if not isinstance(value, list) or len(value) != 4:
+            return None
+
+        min_lon, min_lat, max_lon, max_lat = value
+        if min_lon == max_lon or min_lat == max_lat:
+            return None
+
+        return {
+            "type": "Feature",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [min_lon, min_lat],
+                        [max_lon, min_lat],
+                        [max_lon, max_lat],
+                        [min_lon, max_lat],
+                        [min_lon, min_lat],
+                    ]
+                ],
+            },
+            "properties": {},
+        }
 
     # --- map → value
     def _handle_draw(self, target: DrawControl, action: str, geo_json: dict):
@@ -85,9 +124,4 @@ class BBoxEditor(pn.widgets.WidgetBase, pn.custom.PyComponent):
         bbox: BBox = [min(lons), min(lats), max(lons), max(lats)]
         self.value = bbox
 
-        # replace user layer
-        for layer in list(self._map.layers):
-            if getattr(layer, "name", None) == "user":
-                self._map.remove(layer)
-
-        self._map.add(GeoJSON(name="user", data=geo_json))
+        self._replace_user_layer(geo_json)

--- a/gavicore/src/gavicore/ui/panel/widgets/nullable.py
+++ b/gavicore/src/gavicore/ui/panel/widgets/nullable.py
@@ -13,14 +13,14 @@ class NullableWidget(pn.widgets.WidgetBase, pn.custom.PyComponent):
 
     value = param.Parameter(default=None, allow_None=True)
 
-    def __init__(self, inner_widget: pn.widgets.WidgetBase, **params):
-        super().__init__(**params)
+    def __init__(self, inner_widget: pn.widgets.WidgetBase, name: str = "", **params):
+        super().__init__(name=name or inner_widget.name or "", **params)
 
         if "value" not in inner_widget.param:
             raise ValueError("inner must have a writable 'value' parameter")
 
         self._toggle = pn.widgets.Switch(
-            name=inner_widget.name,
+            name=self.name,
             value=self.value is not None,
             styles={"margin-bottom": "0px"},
         )

--- a/gavicore/tests/ui/field/test_meta.py
+++ b/gavicore/tests/ui/field/test_meta.py
@@ -634,7 +634,9 @@ class FieldMetaTest(TestCase):
                 self.assertEqual(expected, meta.get_initial_value())
 
     def test_get_initial_value_for_date_string(self):
-        meta = FieldMeta.from_schema("x", Schema(**{"type": "string", "format": "date"}))
+        meta = FieldMeta.from_schema(
+            "x", Schema(**{"type": "string", "format": "date"})
+        )
 
         self.assertIsInstance(
             datetime.date.fromisoformat(meta.get_initial_value()),
@@ -664,6 +666,27 @@ class FieldMetaTest(TestCase):
         )
 
         self.assertEqual([-1, -1, -1], meta.get_initial_value())
+
+    def test_get_initial_value_for_array_uses_min_items_and_date_format(self):
+        meta = FieldMeta.from_schema(
+            "x",
+            Schema(
+                **{
+                    "type": "array",
+                    "items": {"type": "string", "format": "date"},
+                    "minItems": 3,
+                }
+            ),
+        )
+
+        self.assertEqual(
+            [
+                (datetime.date.today() - datetime.timedelta(days=2)).isoformat(),
+                (datetime.date.today() - datetime.timedelta(days=1)).isoformat(),
+                (datetime.date.today() - datetime.timedelta(days=0)).isoformat(),
+            ],
+            meta.get_initial_value(),
+        )
 
     def test_get_initial_value_for_array_without_min_items(self):
         meta = FieldMeta.from_schema(

--- a/gavicore/tests/ui/field/test_meta.py
+++ b/gavicore/tests/ui/field/test_meta.py
@@ -2,6 +2,7 @@
 #  Permissions are hereby granted under the terms of the Apache 2.0 License:
 #  https://opensource.org/license/apache-2-0.
 
+import datetime
 from typing import Annotated, Any
 from unittest import TestCase
 
@@ -586,6 +587,135 @@ class FieldMetaTest(TestCase):
             Schema(**{"type": "boolean", "nullable": False}), nn_meta.schema_
         )
         self.assertIs(True, nn_meta.nullable_parent)
+
+    def test_get_initial_value_uses_default_first(self):
+        meta = FieldMeta.from_schema(
+            "x", Schema(**{"type": "boolean", "default": True, "nullable": True})
+        )
+
+        self.assertIs(True, meta.get_initial_value())
+
+    def test_get_initial_value_uses_first_enum_value_before_nullable(self):
+        meta = FieldMeta.from_schema(
+            "x",
+            Schema(
+                **{
+                    "type": "string",
+                    "enum": ["keep", "drop"],
+                    "nullable": True,
+                }
+            ),
+        )
+
+        self.assertEqual("keep", meta.get_initial_value())
+
+    def test_get_initial_value_uses_null_for_nullable_without_default_or_enum(self):
+        meta = FieldMeta.from_schema(
+            "x", Schema(**{"type": "string", "nullable": True})
+        )
+
+        self.assertIsNone(meta.get_initial_value())
+
+    def test_get_initial_value_for_primitives(self):
+        cases = [
+            (Schema(**{"type": "boolean"}), False),
+            (Schema(**{"type": "integer"}), 0),
+            (Schema(**{"type": "integer", "minimum": -4}), -4),
+            (Schema(**{"type": "integer", "maximum": -3}), -3),
+            (Schema(**{"type": "number"}), 0.0),
+            (Schema(**{"type": "number", "minimum": -1.5}), -1.5),
+            (Schema(**{"type": "number", "maximum": -2.5}), -2.5),
+            (Schema(**{"type": "string"}), ""),
+        ]
+
+        for schema, expected in cases:
+            with self.subTest(schema=schema):
+                meta = FieldMeta.from_schema("x", schema)
+                self.assertEqual(expected, meta.get_initial_value())
+
+    def test_get_initial_value_for_date_string(self):
+        meta = FieldMeta.from_schema("x", Schema(**{"type": "string", "format": "date"}))
+
+        self.assertIsInstance(
+            datetime.date.fromisoformat(meta.get_initial_value()),
+            datetime.date,
+        )
+
+    def test_get_initial_value_for_date_time_string(self):
+        meta = FieldMeta.from_schema(
+            "x", Schema(**{"type": "string", "format": "date-time"})
+        )
+
+        self.assertIsInstance(
+            datetime.datetime.fromisoformat(meta.get_initial_value()),
+            datetime.datetime,
+        )
+
+    def test_get_initial_value_for_array_uses_min_items(self):
+        meta = FieldMeta.from_schema(
+            "x",
+            Schema(
+                **{
+                    "type": "array",
+                    "items": {"type": "integer", "maximum": -1},
+                    "minItems": 3,
+                }
+            ),
+        )
+
+        self.assertEqual([-1, -1, -1], meta.get_initial_value())
+
+    def test_get_initial_value_for_array_without_min_items(self):
+        meta = FieldMeta.from_schema(
+            "x",
+            Schema(
+                **{
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": None,
+                }
+            ),
+        )
+
+        self.assertEqual([], meta.get_initial_value())
+
+    def test_get_initial_value_for_object_uses_required_properties_only(self):
+        meta = FieldMeta.from_schema(
+            "x",
+            Schema(
+                **{
+                    "type": "object",
+                    "properties": {
+                        "flag": {"type": "boolean"},
+                        "count": {"type": "integer", "minimum": -2},
+                        "label": {"type": "string", "default": "ignored"},
+                    },
+                    "required": ["flag", "count"],
+                }
+            ),
+        )
+
+        self.assertEqual({"flag": False, "count": -2}, meta.get_initial_value())
+
+    def test_get_initial_value_for_object_without_required_properties(self):
+        meta = FieldMeta.from_schema(
+            "x",
+            Schema(
+                **{
+                    "type": "object",
+                    "properties": {
+                        "flag": {"type": "boolean"},
+                    },
+                }
+            ),
+        )
+
+        self.assertEqual({}, meta.get_initial_value())
+
+    def test_get_initial_value_for_untyped_schema(self):
+        meta = FieldMeta.from_schema("x", Schema(**{}))
+
+        self.assertIsNone(meta.get_initial_value())
 
     # noinspection PyMethodMayBeStatic
     def test_pydantic_deserialization_with_extra_fields(self):

--- a/gavicore/tests/ui/panel/test_array.py
+++ b/gavicore/tests/ui/panel/test_array.py
@@ -1,0 +1,69 @@
+#  Copyright (c) 2026 by the Eozilla team and contributors
+#  Permissions are hereby granted under the terms of the Apache 2.0 License:
+#  https://opensource.org/license/apache-2-0.
+
+from unittest import TestCase
+
+from gavicore.ui.panel.widgets.array import ArrayEditor, ArrayWidget
+from gavicore.util.text import TextConverter
+
+
+class ArrayWidgetTest(TestCase):
+    def test_value_change_updates_text(self):
+        widget = ArrayWidget(
+            value=[0.0, 0.0],
+            array_converter=TextConverter.NumberArray(),
+        )
+
+        widget.value = [10.0, 20.0]
+
+        self.assertEqual("10.0, 20.0", widget._text.value)
+
+    def test_text_change_keeps_entered_text(self):
+        widget = ArrayWidget(
+            value=[0.0, 0.0],
+            array_converter=TextConverter.NumberArray(),
+        )
+
+        widget._text.value = "10, 20"
+
+        self.assertEqual([10.0, 20.0], widget.value)
+        self.assertEqual("10, 20", widget._text.value)
+
+
+class ArrayEditorTest(TestCase):
+    def test_item_change_does_not_recreate_item_editor(self):
+        editor = _number_pair_editor([[0.0, 0.0], [0.0, 0.0]])
+        first_row = editor._items_box[0]
+        first_item_editor = first_row[0]
+
+        first_item_editor._text.value = "10, 20"
+
+        self.assertEqual([[10.0, 20.0], [0.0, 0.0]], editor.value)
+        self.assertIs(first_row, editor._items_box[0])
+        self.assertIs(first_item_editor, editor._items_box[0][0])
+        self.assertEqual([10.0, 20.0], first_item_editor.value)
+        self.assertEqual("10, 20", first_item_editor._text.value)
+
+    def test_external_value_change_recreates_item_editors(self):
+        editor = _number_pair_editor([[0.0, 0.0], [0.0, 0.0]])
+        first_row = editor._items_box[0]
+
+        editor.value = [[10.0, 20.0]]
+
+        self.assertEqual(1, len(editor._items_box))
+        self.assertIsNot(first_row, editor._items_box[0])
+
+
+def _number_pair_editor(value: list[list[float]]) -> ArrayEditor:
+    def create_item_editor(_index: int, item_value: list[float]):
+        return ArrayWidget(
+            value=item_value,
+            array_converter=TextConverter.NumberArray(),
+        )
+
+    return ArrayEditor(
+        value=value,
+        item_value_factory=lambda: [0.0, 0.0],
+        item_editor_factory=create_item_editor,
+    )

--- a/gavicore/tests/ui/panel/test_factory.py
+++ b/gavicore/tests/ui/panel/test_factory.py
@@ -33,6 +33,25 @@ class DefaultPanelFieldFactoryTest(TestCase):
         )
         field = generator.generate_field(meta)
         self.assertIsInstance(field.view, BBoxEditor)
+        self.assertEqual(field.view_model.value, field.view.value)
+
+        field.view.value = [1.0, 2.0, 3.0, 4.0]
+
+        self.assertEqual([1.0, 2.0, 3.0, 4.0], field.view_model.value)
+
+    def test_create_field_for_bbox_format(self):
+        generator = FieldGenerator()
+        generator.register_field_factory(DefaultPanelFieldFactory())
+
+        meta = _meta_from_schema(
+            {
+                "type": "array",
+                "items": {"type": "number"},
+                "format": "bbox",
+            }
+        )
+        field = generator.generate_field(meta)
+        self.assertIsInstance(field.view, BBoxEditor)
 
     def test_create_field_for_date_tuple(self):
         generator = FieldGenerator()

--- a/gavicore/tests/ui/panel/test_factory.py
+++ b/gavicore/tests/ui/panel/test_factory.py
@@ -47,6 +47,8 @@ class DefaultPanelFieldFactoryTest(TestCase):
             {
                 "type": "array",
                 "items": {"type": "number"},
+                "minItems": 4,
+                "maxItems": 4,
                 "format": "bbox",
             }
         )
@@ -109,6 +111,72 @@ class DefaultPanelFieldFactoryTest(TestCase):
         assert isinstance(tabs, pn.layout.Tabs)
         tabs.active = 1
         self.assertEqual({"t": "B", "b": 0}, field.view_model.value)
+
+    def test_nested_array_item_edit_keeps_visible_value(self):
+        generator = FieldGenerator()
+        generator.register_field_factory(DefaultPanelFieldFactory())
+        field = generator.generate_field(
+            _meta_from_schema(
+                {
+                    "oneOf": [
+                        {"$ref": "#/$defs/Point"},
+                        {"$ref": "#/$defs/LineString"},
+                    ],
+                    "discriminator": {
+                        "propertyName": "type",
+                    },
+                    "$defs": {
+                        "Coordinate": {
+                            "type": "array",
+                            "items": {"type": "number"},
+                            "minItems": 2,
+                            "maxItems": 3,
+                        },
+                        "Point": {
+                            "type": "object",
+                            "properties": {
+                                "type": {"type": "string"},
+                                "coordinates": {"$ref": "#/$defs/Coordinate"},
+                            },
+                            "required": ["type", "coordinates"],
+                        },
+                        "LineString": {
+                            "type": "object",
+                            "properties": {
+                                "type": {"type": "string"},
+                                "coordinates": {
+                                    "type": "array",
+                                    "items": {"$ref": "#/$defs/Coordinate"},
+                                    "minItems": 2,
+                                },
+                            },
+                            "required": ["type", "coordinates"],
+                        },
+                    },
+                }
+            )
+        )
+
+        tabs = field.view.inner_viewable
+        assert isinstance(tabs, pn.layout.Tabs)
+        tabs.active = 1
+        line_string_view = tabs[1]
+        coordinates_editor = line_string_view.inner_viewable.objects[0]
+        first_row = coordinates_editor._items_box[0]
+        first_item_editor = first_row[0]
+
+        first_item_editor._text.value = "10, 20"
+
+        self.assertEqual(
+            {
+                "type": "LineString",
+                "coordinates": [[10.0, 20.0], [0.0, 0.0]],
+            },
+            field.view_model.value,
+        )
+        self.assertIs(first_item_editor, coordinates_editor._items_box[0][0])
+        self.assertEqual([10.0, 20.0], first_item_editor.value)
+        self.assertEqual("10, 20", first_item_editor._text.value)
 
     def test_create_field_for_combinations(self):
         self.assert_create_field_for_combinations("oneOf")

--- a/wraptile/src/wraptile/services/local/testing.py
+++ b/wraptile/src/wraptile/services/local/testing.py
@@ -112,7 +112,9 @@ def primes_between(
         "bbox": Field(
             title="Bounding box",
             description="Bounding box in geographical coordinates.",
-            json_schema_extra=dict(format="bbox"),
+            json_schema_extra={"x-ui-widget": "map"},
+            min_length=4,
+            max_length=4,
         ),
         "resolution": Field(
             title="Spatial resolution",

--- a/wraptile/tests/services/local/test_testing.py
+++ b/wraptile/tests/services/local/test_testing.py
@@ -128,10 +128,10 @@ class TestingServiceTest(IsolatedAsyncioTestCase):
             {
                 "type": "array",
                 "default": [-180, -90, 180, 90],
-                "format": "bbox",
                 "items": {"type": "number"},
                 "minItems": 4,
                 "maxItems": 4,
+                "x-ui-widget": "map",
             },
             bbox_input.schema_.model_dump(
                 mode="json",


### PR DESCRIPTION
Closes #101

This PR fixes regressions in new GUI generator:

- [x] Date ranges should be initialized with two different dates, but only current date is set.
- [x] Array-Bbox isn't rendered at all, but it should render a leaflet map.
- [x] Within oneOf / discriminator: Array values when entered are reflected in the value of the view-model but the UI jumps back to initial value in UI, while actual view-model value remains.
- [x] Array items should not have titles, but titles are rendered.
- [x] Strings with min length are initialized with `+` characters. They should not be initialized, as min length should be validation only.
- [x] Nullable properties are rendered without title. They should be rendered with title.

Checklist (strike out non-applicable):

* [x] Changes documented in `CHANGES.md`
* [x] Related issue exists and is referred to in the PR description and `CHANGES.md`
* [ ] ~Added docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~Changes/features documented in `docs/*`~
* [x] Unit-tests adapted/added for changes/features 
* [x] Test coverage remains or increases (target 100%)
