### PR TITLE
Implemented airflow params ogc input mapping

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,11 +4,16 @@
 
 - Wraptile server now configures CORS so that it can be accessed
   from browsers running web apps. (#107)
+- Wraptile's Airflow service now maps Airflow DAG `Param` definitions to
+  OGC process input descriptions, so `cuiman`'s GUI renders input fields
+  (including type, title, description, default value, and nullable object params)
+  for Airflow-backed processes.
 
 ### Fixes
 
 - Added missing API docs to `docs/cuiman/api.md` (deployed shortly after 0.1.0 release)
 - Fixed the PyPI release workflow (applied shortly after 0.1.0 release)
+- Fixed nullable input fields showing an empty label in the `cuiman` GUI.
 
 ### Other changes
 

--- a/gavicore/src/gavicore/ui/panel/factory.py
+++ b/gavicore/src/gavicore/ui/panel/factory.py
@@ -62,7 +62,7 @@ class DefaultPanelFieldFactory(PanelFieldFactoryBase):
         return PanelField(
             view_model,
             NullableWidget(
-                name=ctx.name,
+                name=ctx.label,
                 value=ctx.initial_value,
                 inner_widget=non_nullable_field.view,
             ),

--- a/gavicore/src/gavicore/ui/panel/widgets/nullable.py
+++ b/gavicore/src/gavicore/ui/panel/widgets/nullable.py
@@ -20,7 +20,7 @@ class NullableWidget(pn.widgets.WidgetBase, pn.custom.PyComponent):
             raise ValueError("inner must have a writable 'value' parameter")
 
         self._toggle = pn.widgets.Switch(
-            name=inner_widget.name,
+            name=self.name,
             value=self.value is not None,
             styles={"margin-bottom": "0px"},
         )

--- a/wraptile/src/wraptile/services/airflow/airflow_service.py
+++ b/wraptile/src/wraptile/services/airflow/airflow_service.py
@@ -3,9 +3,12 @@
 #  https://opensource.org/license/apache-2-0.
 
 import datetime
+import logging
 import os
 from functools import cached_property
 from typing import Any, Optional
+
+_log = logging.getLogger(__name__)
 
 import fastapi
 import requests
@@ -112,12 +115,11 @@ class AirflowService(ServiceBase):
 
         inputs: dict[str, InputDescription] = {}
         if dag_details.params:
-            # TODO: check that 'param_value' will be an instance of 'Param' model
             for param_key, param_value in dag_details.params.items():
-                # TODO: inputs[param_key] = InputDescription(param_value. ...)
-                print(f"    - {param_key} = {param_value} (type {type(param_value)}):")
-        else:
-            print("  No parameters (params) defined for this DAG.")
+                _log.debug("DAG param %r: %r", param_key, param_value)
+                input_desc = self._param_to_input_description(param_key, param_value)
+                if input_desc is not None:
+                    inputs[param_key] = input_desc
 
         # TODO: where to get outputs from?
         outputs: dict[str, OutputDescription] = {}
@@ -129,6 +131,29 @@ class AirflowService(ServiceBase):
             description=dag_details.doc_md or dag_details.description,
             inputs=inputs,
             outputs=outputs,
+        )
+
+    @staticmethod
+    def _param_to_input_description(
+        param_key: str, param_value: Any
+    ) -> InputDescription | None:
+        if not isinstance(param_value, dict):
+            return None
+        schema_dict: dict = param_value.get("schema", {})
+        default = param_value.get("value")
+        title = schema_dict.get("title")
+        description = param_value.get("description") or schema_dict.get("description")
+        nullable = bool(schema_dict.get("nullable", False))
+        schema_override: dict[str, Any] = {"default": default, "description": description}
+        if title is not None:
+            schema_override["title"] = title
+        return InputDescription.model_validate(
+            {
+                "schema": {**schema_dict, **schema_override},
+                "title": title,
+                "description": description,
+                "minOccurs": 0 if nullable else 1,
+            }
         )
 
     async def execute_process(

--- a/wraptile/src/wraptile/services/airflow/airflow_service.py
+++ b/wraptile/src/wraptile/services/airflow/airflow_service.py
@@ -8,8 +8,6 @@ import os
 from functools import cached_property
 from typing import Any, Optional
 
-_log = logging.getLogger(__name__)
-
 import fastapi
 import requests
 from airflow_client.client import (
@@ -41,6 +39,8 @@ from gavicore.models import (
 from procodile.workflow import FINAL_STEP_ID
 from wraptile.exceptions import ServiceException
 from wraptile.services.base import ServiceBase
+
+_log = logging.getLogger(__name__)
 
 DEFAULT_AIRFLOW_BASE_URL = "http://localhost:8080"
 

--- a/wraptile/tests/services/airflow/test_airflow_service.py
+++ b/wraptile/tests/services/airflow/test_airflow_service.py
@@ -4,7 +4,7 @@
 
 import unittest
 import warnings
-from unittest import IsolatedAsyncioTestCase
+from unittest import IsolatedAsyncioTestCase, TestCase
 
 import fastapi
 import requests
@@ -12,6 +12,7 @@ import requests
 from gavicore.models import (
     Capabilities,
     ConformanceDeclaration,
+    DataType,
     ProcessDescription,
     ProcessList,
 )
@@ -19,6 +20,118 @@ from gavicore.util.testing import set_env
 from wraptile.main import app
 from wraptile.provider import ServiceProvider, get_service
 from wraptile.services.airflow import DEFAULT_AIRFLOW_BASE_URL, AirflowService
+
+
+class ParamToInputDescriptionTest(TestCase):
+    def test_string_param(self):
+        result = AirflowService._param_to_input_description(
+            "scene_name",
+            {
+                "value": "scene",
+                "description": "Scene id name.",
+                "schema": {"type": "string", "title": "Scene Name"},
+            },
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result.title, "Scene Name")
+        self.assertEqual(result.description, "Scene id name.")
+        self.assertEqual(result.schema_.type, DataType.string)
+        self.assertEqual(result.schema_.default, "scene")
+        self.assertEqual(result.minOccurs, 1)
+
+    def test_number_param(self):
+        result = AirflowService._param_to_input_description(
+            "target_lat",
+            {
+                "value": 41.808,
+                "description": "Target's center latitude.",
+                "schema": {"type": "number", "title": "Target Lat"},
+            },
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result.schema_.type, DataType.number)
+        self.assertEqual(result.schema_.default, 41.808)
+        self.assertEqual(result.minOccurs, 1)
+
+    def test_integer_param(self):
+        result = AirflowService._param_to_input_description(
+            "spp",
+            {
+                "value": 8,
+                "description": "Number of Monte Carlo samples.",
+                "schema": {"type": "integer", "title": "Spp"},
+            },
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result.schema_.type, DataType.integer)
+        self.assertEqual(result.schema_.default, 8)
+
+    def test_nullable_object_param(self):
+        result = AirflowService._param_to_input_description(
+            "config_output_dir_generation",
+            {
+                "value": {"value": "s3://output/gen_config", "cid": "s3ovh"},
+                "description": "Generation configuration output directory.",
+                "schema": {
+                    "type": "object",
+                    "nullable": True,
+                    "properties": {
+                        "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "Full path URI",
+                        },
+                        "cid": {"title": "Cid", "description": "Credential ID"},
+                    },
+                    "required": ["value"],
+                },
+            },
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result.schema_.type, DataType.object)
+        self.assertTrue(result.schema_.nullable)
+        self.assertEqual(result.minOccurs, 0)
+        self.assertIsNotNone(result.schema_.properties)
+        self.assertIn("value", result.schema_.properties)
+        self.assertIn("cid", result.schema_.properties)
+        self.assertEqual(result.schema_.properties["value"].type, DataType.string)
+        self.assertEqual(result.schema_.required, ["value"])
+        self.assertEqual(
+            result.schema_.default,
+            {"value": "s3://output/gen_config", "cid": "s3ovh"},
+        )
+
+    def test_title_is_none_when_absent_from_schema(self):
+        # When schema has no title, we leave it None so gavicore's _make_label
+        # can produce a pretty label (e.g. "my_param" → "My Param").
+        result = AirflowService._param_to_input_description(
+            "my_param",
+            {"value": 1, "description": "desc", "schema": {"type": "integer"}},
+        )
+        self.assertIsNotNone(result)
+        self.assertIsNone(result.title)
+        self.assertIsNone(result.schema_.title)
+
+    def test_description_falls_back_to_schema_description(self):
+        result = AirflowService._param_to_input_description(
+            "my_param",
+            {"value": 1, "schema": {"type": "integer", "description": "from schema"}},
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result.description, "from schema")
+
+    def test_non_dict_param_returns_none(self):
+        result = AirflowService._param_to_input_description("bad_param", "not a dict")
+        self.assertIsNone(result)
+
+    def test_missing_schema_key(self):
+        result = AirflowService._param_to_input_description(
+            "bare_param",
+            {"value": 42},
+        )
+        self.assertIsNotNone(result)
+        self.assertIsNone(result.schema_.type)
+        self.assertEqual(result.schema_.default, 42)
 
 
 def is_airflow_running(url: str, timeout: float = 1.0) -> bool:


### PR DESCRIPTION
[Description of PR]
Wraptile's Airflow service now maps Airflow DAG Param definitions to OGC process input descriptions, so cuiman's GUI renders input fields (including type, title, description, default value, and nullable object params) for Airflow-backed processes.
Checklist (strike out non-applicable):

* [x] Changes documented in `CHANGES.md`
~* [ ] Related issue exists and is referred to in the PR description and `CHANGES.md`~
~* [ ] Added docstrings and API docs for any new/modified user-facing classes and functions~
~* [ ] Changes/features documented in `docs/*`~
* [x] Unit-tests adapted/added for changes/features 
* [x] Test coverage remains or increases (target 100%)
