### PR TITLE
Fixed appligator unit test failing on Windows OS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 - Added missing API docs to `docs/cuiman/api.md` (deployed shortly after 0.1.0 release)
 - Fixed the PyPI release workflow (applied shortly after 0.1.0 release)
 - Fixed nullable input fields showing an empty label in the `cuiman` GUI.
+- Fixed test `appligator\tests\airflow\test_gen_dockerfile.py` failing on Windows OS.
 
 ### Other changes
 

--- a/appligator/src/appligator/airflow/gen_dockerfile.py
+++ b/appligator/src/appligator/airflow/gen_dockerfile.py
@@ -4,7 +4,7 @@
 
 import shutil
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -229,7 +229,7 @@ def _copy_pyproject_toml_stripped(src: Path, dest: Path) -> None:
             if not (
                 isinstance(spec, dict)
                 and "path" in spec
-                and (Path(spec["path"]).is_absolute() or spec["path"].startswith(".."))
+                and _path_escapes_build_context(spec["path"])
             )
         }
 
@@ -245,3 +245,29 @@ def _copy_pyproject_toml_stripped(src: Path, dest: Path) -> None:
             )
 
     dest.write_bytes(tomli_w.dumps(data).encode())
+
+
+def _path_escapes_build_context(path: str) -> bool:
+    """Return True when a dependency path would not exist inside the build context.
+
+    TOML path dependencies may use either POSIX-style or Windows-style absolute
+    syntax regardless of the host platform. We therefore classify absolute
+    paths using both pure path parsers and then normalize relative segments to
+    catch paths that walk outside the context via ``..``.
+    """
+    if PurePosixPath(path).is_absolute() or PureWindowsPath(path).is_absolute():
+        return True
+
+    normalized_parts: list[str] = []
+    for part in path.replace("\\", "/").split("/"):
+        if not part or part == ".":
+            continue
+        if part == "..":
+            if normalized_parts and normalized_parts[-1] != "..":
+                normalized_parts.pop()
+            else:
+                normalized_parts.append(part)
+            continue
+        normalized_parts.append(part)
+
+    return bool(normalized_parts and normalized_parts[0] == "..")

--- a/appligator/tests/airflow/test_gen_dockerfile.py
+++ b/appligator/tests/airflow/test_gen_dockerfile.py
@@ -8,6 +8,7 @@ import pytest
 
 from appligator.airflow.gen_dockerfile import (
     _copy_pyproject_toml_stripped,
+    _path_escapes_build_context,
     generate,
 )
 
@@ -425,3 +426,11 @@ class TestCopyPyprojectTomlStripped:
             "pypi-dependencies"
         ]
         assert "appligator" not in feature_deps
+
+
+class TestPathEscapesBuildContext:
+    def test_current_dir_segments_are_ignored(self):
+        assert _path_escapes_build_context("packages/./mypkg") is False
+
+    def test_parent_dir_segments_inside_context_are_collapsed(self):
+        assert _path_escapes_build_context("packages/inner/../mypkg") is False

--- a/appligator/tests/airflow/test_gen_dockerfile.py
+++ b/appligator/tests/airflow/test_gen_dockerfile.py
@@ -384,6 +384,19 @@ class TestCopyPyprojectTomlStripped:
         data = tomllib.loads(dest.read_text())
         assert "mypkg" not in data["tool"]["pixi"]["pypi-dependencies"]
 
+    def test_windows_absolute_path_dep_stripped(self, tmp_path):
+        src = tmp_path / "pyproject.toml"
+        src.write_text(
+            "[tool.pixi.pypi-dependencies]\n"
+            'mypkg = { path = "C:\\\\Users\\\\norma\\\\mypkg", editable = true }\n'
+        )
+        dest = tmp_path / "out.toml"
+        _copy_pyproject_toml_stripped(src, dest)
+        import tomllib
+
+        data = tomllib.loads(dest.read_text())
+        assert "mypkg" not in data["tool"]["pixi"]["pypi-dependencies"]
+
     def test_local_packages_dep_kept(self, tmp_path):
         src = tmp_path / "pyproject.toml"
         src.write_text(


### PR DESCRIPTION
Fixed test `appligator\tests\airflow\test_gen_dockerfile.py` failing on Windows OS.
Original root cause was already in #81.

Checklist (strike out non-applicable):

* [x] Changes documented in `CHANGES.md`
* [ ] ~Related issue exists and is referred to in the PR description and `CHANGES.md`~
* [ ] ~Added docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~Changes/features documented in `docs/*`~
* [x] Unit-tests adapted/added for changes/features 
* [x] Test coverage remains or increases (target 100%)


```
Pixi task (test-appligator): pytest appligator/tests
====================================================================== test session starts ======================================================================
platform win32 -- Python 3.14.4, pytest-9.0.3, pluggy-1.6.0
rootdir: C:\Users\norma\Projects\eozilla\appligator
configfile: pyproject.toml
plugins: anyio-4.13.0, asyncio-1.3.0, cov-7.1.0, typeguard-4.5.1, zarr-3.1.6
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 125 items                                                                                                                                              

appligator\tests\airflow\handlers\test_base_handler.py ..                                                                                                  [  1%]
appligator\tests\airflow\handlers\test_k8s_handler.py ............                                                                                         [ 11%]
appligator\tests\airflow\handlers\test_syn_python_handler.py ...                                                                                           [ 13%]
appligator\tests\airflow\test_gen_dockerfile.py .....................................F..                                                                   [ 45%]
appligator\tests\airflow\test_gen_workflow_dag.py ........                                                                                                 [ 52%]
appligator\tests\airflow\test_renderer.py ..............                                                                                                   [ 63%]
appligator\tests\airflow\test_run_step.py ..........                                                                                                       [ 71%]
appligator\tests\airflow\test_workflow_to_ir.py ...........                                                                                                [ 80%]
appligator\tests\test_cli.py ..............                                                                                                                [ 91%]
appligator\tests\test_config.py ...........                                                                                                                [100%]

=========================================================================== FAILURES ============================================================================
_________________________________________________ TestCopyPyprojectTomlStripped.test_absolute_path_dep_stripped _________________________________________________

self = <tests.airflow.test_gen_dockerfile.TestCopyPyprojectTomlStripped object at 0x000001A2FEDC07D0>
tmp_path = WindowsPath('C:/Users/norma/AppData/Local/Temp/pytest-of-norma/pytest-0/test_absolute_path_dep_strippe0')

    def test_absolute_path_dep_stripped(self, tmp_path):
        src = tmp_path / "pyproject.toml"
        src.write_text(
            "[tool.pixi.pypi-dependencies]\n"
            'mypkg = { path = "/home/user/mypkg", editable = true }\n'
        )
        dest = tmp_path / "out.toml"
        _copy_pyproject_toml_stripped(src, dest)
        import tomllib
    
        data = tomllib.loads(dest.read_text())
>       assert "mypkg" not in data["tool"]["pixi"]["pypi-dependencies"]
E       AssertionError: assert 'mypkg' not in {'mypkg': {'editable': True, 'path': '/home/user/mypkg'}}

appligator\tests\airflow\test_gen_dockerfile.py:385: AssertionError
==================================================================== short test summary info ====================================================================
FAILED appligator\tests\airflow\test_gen_dockerfile.py::TestCopyPyprojectTomlStripped::test_absolute_path_dep_stripped - AssertionError: assert 'mypkg' not in {'mypkg': {'editable': True, 'path': '/home/user/mypkg'}}
================================================================= 1 failed, 124 passed in 6.45s =================================================================
```

