### PR TITLE
Initial Interface Extensions According to OGC API - Processes part 2

### DIFF
--- a/docs/gavicore/models/api.md
+++ b/docs/gavicore/models/api.md
@@ -31,6 +31,29 @@
 ::: gavicore.models.JobResult
 
 
+## `gavicore.models` - OGC Application Package and Workflow descriptions
+
+::: gavicore.models.CWLDescription
+
+::: gavicore.models.ContainerConfig
+
+::: gavicore.models.InputBinding
+
+::: gavicore.models.OutputBinding
+
+::: gavicore.models.ContainerBindings
+
+::: gavicore.models.ExecutionUnitContainer
+
+::: gavicore.models.ContainerImage
+
+::: gavicore.models.GenericExecutionUnit
+
+::: gavicore.models.ExecutionUnitBase
+
+::: gavicore.models.OGCApplicationPackage
+
+
 ## `gavicore.models` - OpenAPI Schema
 
 ::: gavicore.models.DataType

--- a/docs/gavicore/models/api.md
+++ b/docs/gavicore/models/api.md
@@ -33,25 +33,25 @@
 
 ## `gavicore.models` - OGC Application Package and Workflow descriptions
 
-::: gavicore.models.CWLDescription
+::: gavicore.dru_models.OGCApplicationPackage
 
-::: gavicore.models.ContainerConfig
+::: gavicore.dru_models.OGCApplicationPackageProcessDescription
 
-::: gavicore.models.InputBinding
+::: gavicore.dru_models.CWLDescription
 
-::: gavicore.models.OutputBinding
+::: gavicore.dru_models.ContainerImage
 
-::: gavicore.models.ContainerBindings
+::: gavicore.dru_models.ExecutionUnitContainer
 
-::: gavicore.models.ExecutionUnitContainer
+::: gavicore.dru_models.ContainerConfig
 
-::: gavicore.models.ContainerImage
+::: gavicore.dru_models.ContainerBindings
 
-::: gavicore.models.GenericExecutionUnit
+::: gavicore.dru_models.InputBinding
 
-::: gavicore.models.ExecutionUnitBase
+::: gavicore.dru_models.OutputBinding
 
-::: gavicore.models.OGCApplicationPackage
+::: gavicore.dru_models.GenericExecutionUnit
 
 
 ## `gavicore.models` - OpenAPI Schema

--- a/docs/gavicore/service/api.md
+++ b/docs/gavicore/service/api.md
@@ -1,3 +1,5 @@
 # `gavicore.service` API Reference
 
 ::: gavicore.service.Service
+
+::: gavicore.dru_service.DRUService

--- a/gavicore/src/gavicore/__init__.py
+++ b/gavicore/src/gavicore/__init__.py
@@ -7,12 +7,13 @@ from importlib.metadata import version
 
 from pydantic import BaseModel
 
-from . import models, service
+from . import dru_service, models, service
 
 __version__ = version("gavicore")
 
 __all__ = [
     "__version__",
+    "dru_service",
     "models",
     "service",
 ]

--- a/gavicore/src/gavicore/__init__.py
+++ b/gavicore/src/gavicore/__init__.py
@@ -7,12 +7,13 @@ from importlib.metadata import version
 
 from pydantic import BaseModel
 
-from . import dru_service, models, service
+from . import dru_models, dru_service, models, service
 
 __version__ = version("gavicore")
 
 __all__ = [
     "__version__",
+    "dru_models",
     "dru_service",
     "models",
     "service",
@@ -20,10 +21,15 @@ __all__ = [
 
 
 def _patch_models():
-    for name, obj in inspect.getmembers(models, inspect.isclass):
+    for name, obj in inspect.getmembers(models, inspect.isclass) + inspect.getmembers(
+        dru_models, inspect.isclass
+    ):
         if (
             not name.startswith("_")
-            and obj.__module__ == models.__name__
+            and (
+                obj.__module__ == models.__name__
+                or obj.__module__ == dru_models.__name__
+            )
             and issubclass(obj, BaseModel)
         ):
             # Make model object render nicely in Jupyter notebooks

--- a/gavicore/src/gavicore/dru_models.py
+++ b/gavicore/src/gavicore/dru_models.py
@@ -1,0 +1,212 @@
+#  Copyright (c) 2025-2026 by the Eozilla team and contributors
+#  Permissions are hereby granted under the terms of the Apache 2.0 License:
+#  https://opensource.org/license/apache-2-0.
+
+from __future__ import annotations
+
+from typing import Annotated, Literal, TypeAlias
+
+from pydantic import BaseModel, Field
+
+from .models import Link, OgcBaseModel, ProcessDescription
+
+# ---------------------------------------------------------------------
+#    OGC Application Package and Workflow descriptions
+# ---------------------------------------------------------------------
+
+
+class OGCApplicationPackage(BaseModel):
+    """
+    An OGC Application Package is a document that describes a process in
+    sufficient detail so that an implementation of this Standard can
+    dynamically deploy that process and make it accessible via an the
+    processes API defined in "OGC API - Processes - Part 1: Core".
+
+    For more information, see: /req/ogcapppkg/schema
+    """
+
+    process_description: OGCApplicationPackageProcessDescription | None = Field(
+        None, alias="processDescription"
+    )
+    """Process description of a given process."""
+
+    execution_uni: ExecutionUnitBase | list[ExecutionUnitBase] = Field(
+        alias="executionUnit"
+    )
+    """The execution unit of process."""
+
+
+class OGCApplicationPackageProcessDescription(BaseModel):
+    """Wrapper around `ProcessDescription` to insert additional field name."""
+
+    process: ProcessDescription | None = None
+    """The process description."""
+
+
+class CWLDescription(BaseModel):
+    """
+    Possible encoding of an execution unit as CWL.
+    """
+
+    media_type: Annotated[Literal["application/cwl"], Field(..., alias="mediaType")]
+    """Media type used to identify the execution unit type.
+    Must always be 'application/cwl'."""
+
+    value: str | None = None
+    """JSON-encoded CWL document."""
+
+
+class ContainerImage(BaseModel):
+    """The execute unit is a container image."""
+
+    type: Literal["docker", "oci"]
+    """Type of container image."""
+
+    value: ExecutionUnitContainer | None = None
+    """Description of container image"""
+
+
+class ExecutionUnitContainer(OgcBaseModel):
+    """Execution unit described by a container image."""
+
+    image: str
+    """Container image reference for the execution unit."""
+
+    deployment: Literal["local", "remote", "hpc", "cloud"] | None = None
+    """Deployment information for the execution unit."""
+
+    config: ContainerConfig | None = None
+    """Optional configuration for image execution."""
+
+    bindings: ContainerBindings | None = None
+    """Binding properties for inputs and outputs."""
+
+
+class ContainerConfig(OgcBaseModel):
+    """Hardware requirements and configuration properties
+    for executing the process."""
+
+    cpu_min: int | None = Field(None, ge=1, alias="cpuMin")
+    """Minimum number of CPUs required to run the process (unit is CPU core)."""
+
+    cpu_max: int | None = Field(None, alias="cpuMax")
+    """Maximum number of CPU dedicated to the process (unit is CPU core)."""
+
+    memory_min: int | float | None = Field(None, alias="memoryMin")
+    """Minimum RAM memory required to run the application (unit is GB)."""
+
+    memory_max: int | float | None = Field(None, alias="memoryMax")
+    """Maximum RAM memory dedicated to the application (unit is GB)."""
+
+    storage_temp_min: int | float | None = Field(None, alias="storageTempMin")
+    """ Minimum required temporary storage size (unit is GB)."""
+
+    storage_outputs_min: int | float | None = Field(None, alias="storageOutputsMin")
+    """Minimum required output storage size (unit is GB)."""
+
+    job_timeout: int | float | None = Field(None, alias="jobTimeout")
+    """Timeout delay for a job execution (in seconds)."""
+
+
+class ContainerBindings(BaseModel):
+    """Input and output bindings of a container image execution unit."""
+
+    input_bindings: InputBinding | None = Field(None, alias="inputBindings")
+    """Input bindings."""
+
+    output_bindings: OutputBinding | None = Field(None, alias="outputBindings")
+    """Output bindings."""
+
+
+class InputBinding(BaseModel):
+    """Defines how to specify the input for the execution unit.
+
+    - The value of various properties defined below can be expressions.
+      - The expression language SHALL be JavaScript(???).
+    - The "$(...)" syntax can be used to reference the current input or other
+        process inputs in an expression.
+        - The value "self" refers to the value of the current input.
+        - The value "inputs.<other_input>" refers to the value of another
+        process input.
+        - If the input is defined as a string of format "file" or "directory"
+        then the meta-values ".path", ".basename", ".nameroot" and ".nameext"
+        can be used to manipulate file or directory name without having to
+        resort to complex regular expressions.
+            - ".path" returns the path of a file name without the file name
+            - ".basename" returns the name of the file without the path
+            - ".nameroot" returns the basename without any extension
+            - ".nameext" returns the extension of the basename
+    """
+
+    prefix: str | None = None
+    """Command line prefix to add before the value."""
+
+    position: int | str | None = None
+    """
+    - The zero-based sorting key.
+    - The value can be an integer or a string.
+    - If the value is a string then it should be an expression that evaluates
+    to a single integer value or null.
+    """
+
+    value_from: str | None = Field(None, alias="valueFrom")
+    """
+    - If valueFrom is a constant string value, use this as the value.
+    - If valueFrom is an expression, evaluate the expression to yield the
+    actual value to use to build the command line.
+    - If the value of the associated input parameter is null, valueFrom is
+    not evaluated and nothing is added to the command line.
+    """
+
+    item_separator: str | None = Field(None, alias="itemSeparator")
+    """ Join the array elements into a single string with the elements
+    separated by itemSeparator."""
+
+    shell_quote: bool | None = Field(None, alias="shellQuote")
+    """
+    - A Boolean that controls whether the value is quoted on the command.
+    - A value of true (or if shecllQuote is not provided) means that the
+      implementation SHALL not permit the interpretation of any shell
+      metacharacters or directives.
+    - A value of false should be used to inject metacharacters for operations
+    such as pipes.
+    """
+
+
+class OutputBinding(OgcBaseModel):
+    """Defines how to retrieve the output result from the command."""
+
+    glob: str | list[str] | None = None
+    """
+    - Wildcard pattern to find the output on disk or mounted volume.
+    - Uses UNIX "glob" wildcard patterns (see: "man 7 glob").
+    - See inputBinding.yaml (modeled as InputBinding) for referencing
+      input values in an output
+      binding "glob" expression.
+    """
+
+
+class GenericExecutionUnit(BaseModel):
+    """A generic execution unit.
+
+    The standard notes:
+        The execution unit is not Docker/OCI or CWL and cannot be properly
+        described via the "mediaType" property of a qualified value
+        using an RFC 2046 media type (e.g. an "R" or "Python" script).
+        In this case a community-defined or custom token may be used
+        with the "type" property.
+    """
+
+    type: str
+    """Type of execution unit"""
+
+
+ExecutionUnitBase: TypeAlias = (
+    Link | CWLDescription | ContainerImage | GenericExecutionUnit
+)
+"""Execution unit encoding of a process."""
+
+ContainerBindings.model_rebuild()
+ExecutionUnitContainer.model_rebuild()
+ContainerImage.model_rebuild()
+OGCApplicationPackage.model_rebuild()

--- a/gavicore/src/gavicore/dru_service.py
+++ b/gavicore/src/gavicore/dru_service.py
@@ -1,10 +1,8 @@
 from abc import ABC, abstractmethod
 from typing import Optional
 
-from .models import (
-    OGCApplicationPackage,
-    ProcessSummary,
-)
+from .dru_models import OGCApplicationPackage
+from .models import ProcessSummary
 from .service import Service
 
 

--- a/gavicore/src/gavicore/dru_service.py
+++ b/gavicore/src/gavicore/dru_service.py
@@ -28,8 +28,8 @@ class DRUService(Service, ABC):
         [OGC API - Processes — Part 2 (DRU)](https://docs.ogc.org/DRAFTS/20-044.html#deploy).
 
         Args:
-            w: Optional workflow id used as the entry point when
-                registring a new process.
+            w: Optionally point to the workflow identifier for deploying a
+                CWL containing multiple workflow definitions.
         """
 
     @abstractmethod
@@ -52,8 +52,8 @@ class DRUService(Service, ABC):
         Args:
             process_id: Unique identifier of registered process
                 that is to be replaced.
-            w: Optional workflow id used as the entry point when
-                registring a new process.
+            w: Optionally point to the workflow identifier for deploying a
+                CWL containing multiple workflow definitions.
         """
 
     @abstractmethod

--- a/gavicore/src/gavicore/dru_service.py
+++ b/gavicore/src/gavicore/dru_service.py
@@ -9,17 +9,27 @@ from .service import Service
 
 
 class DRUService(Service, ABC):
-    """The DRUService interface extends the Service interface by providing four endpoints defined per [OGC API - Processes — Part 2 (DRU)](https://docs.ogc.org/DRAFTS/20-044.html)."""
+    """The DRUService interface extends the Service interface by providing
+    four endpoints defined per
+    [OGC API - Processes — Part 2 (DRU)](https://docs.ogc.org/DRAFTS/20-044.html)."""
 
     @abstractmethod
     async def deploy_process(
         self, w: str | None = None, *args, **kwargs
     ) -> Optional[ProcessSummary]:
-        """Deploy a new process to a server supporting OGC API - Processes — Part 2 (DRU) by providing a process description in a supported format.
+        """Deploy a new process to a server supporting
+        OGC API - Processes — Part 2 (DRU) by providing a process
+        description in a supported format.
 
-        Depending on the service implementation, the server may not return a response body.
+        Depending on the service implementation,
+        the server may not return a response body.
 
-        For more information, see [OGC API - Processes — Part 2 (DRU)](https://docs.ogc.org/DRAFTS/20-044.html#deploy).
+        For more information, see
+        [OGC API - Processes — Part 2 (DRU)](https://docs.ogc.org/DRAFTS/20-044.html#deploy).
+
+        Args:
+            w: Optional workflow id used as the entry point when
+                registring a new process.
         """
 
     @abstractmethod
@@ -30,25 +40,47 @@ class DRUService(Service, ABC):
         *args,
         **kwargs,
     ) -> Optional[ProcessSummary]:
-        """Replace an exisitng and mutable process by providing a new process description in a supported format.
+        """Replace an exisitng and mutable process by providing a new
+        process description in a supported format.
 
-        Depending on the service implementation, the server may not return a response body.
+        Depending on the service implementation,
+        the server may not return a response body.
 
-        For more information, see [OGC API - Processes — Part 2 (DRU)](https://docs.ogc.org/DRAFTS/20-044.html#replace).
+        For more information, see
+        [OGC API - Processes — Part 2 (DRU)](https://docs.ogc.org/DRAFTS/20-044.html#replace).
+
+        Args:
+            process_id: Unique identifier of registered process
+                that is to be replaced.
+            w: Optional workflow id used as the entry point when
+                registring a new process.
         """
 
     @abstractmethod
     async def undeploy_process(self, process_id: str, *args, **kwargs) -> None:
-        """Remove an exisitng and mutable process by providing its process id.
+        """Remove an exisitng and mutable process by providing
+        its process id.
 
-        For more information, see [OGC API - Processes — Part 2 (DRU)](https://docs.ogc.org/DRAFTS/20-044.html#undeploy).
+        For more information, see
+        [OGC API - Processes — Part 2 (DRU)](https://docs.ogc.org/DRAFTS/20-044.html#undeploy).
+
+        Args:
+            process_id: Unique identifier of registered process
+                that is to be replaced.
         """
 
     @abstractmethod
     async def get_formal_description(
         self, process_id: str, *args, **kwargs
     ) -> OGCApplicationPackage:
-        """Retrieve a formal description of a previously deployed process via the deploy operation. The returned description relates to the most recent deployment.
+        """Retrieve a formal description of a previously deployed process
+        via the deploy operation.
+        The returned description relates to the most recent deployment.
 
-        For more information, see [OGC API - Processes — Part 2 (DRU)](https://docs.ogc.org/DRAFTS/20-044.html#application-package-retrieval-operation).
+        For more information, see
+        [OGC API - Processes — Part 2 (DRU)](https://docs.ogc.org/DRAFTS/20-044.html#application-package-retrieval-operation).
+
+        Args:
+            process_id: Unique identifier of registered process
+                that is to be replaced.
         """

--- a/gavicore/src/gavicore/dru_service.py
+++ b/gavicore/src/gavicore/dru_service.py
@@ -1,0 +1,54 @@
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from .models import (
+    OGCApplicationPackage,
+    ProcessSummary,
+)
+from .service import Service
+
+
+class DRUService(Service, ABC):
+    """The DRUService interface extends the Service interface by providing four endpoints defined per [OGC API - Processes — Part 2 (DRU)](https://docs.ogc.org/DRAFTS/20-044.html)."""
+
+    @abstractmethod
+    async def deploy_process(
+        self, w: str | None = None, *args, **kwargs
+    ) -> Optional[ProcessSummary]:
+        """Deploy a new process to a server supporting OGC API - Processes — Part 2 (DRU) by providing a process description in a supported format.
+
+        Depending on the service implementation, the server may not return a response body.
+
+        For more information, see [OGC API - Processes — Part 2 (DRU)](https://docs.ogc.org/DRAFTS/20-044.html#deploy).
+        """
+
+    @abstractmethod
+    async def replace_process(
+        self,
+        process_id: str,
+        w: str | None = None,
+        *args,
+        **kwargs,
+    ) -> Optional[ProcessSummary]:
+        """Replace an exisitng and mutable process by providing a new process description in a supported format.
+
+        Depending on the service implementation, the server may not return a response body.
+
+        For more information, see [OGC API - Processes — Part 2 (DRU)](https://docs.ogc.org/DRAFTS/20-044.html#replace).
+        """
+
+    @abstractmethod
+    async def undeploy_process(self, process_id: str, *args, **kwargs) -> None:
+        """Remove an exisitng and mutable process by providing its process id.
+
+        For more information, see [OGC API - Processes — Part 2 (DRU)](https://docs.ogc.org/DRAFTS/20-044.html#undeploy).
+        """
+
+    @abstractmethod
+    async def get_formal_description(
+        self, process_id: str, *args, **kwargs
+    ) -> OGCApplicationPackage:
+        """Retrieve a formal description of a previously deployed process via the deploy operation. The returned description relates to the most recent deployment.
+
+        For more information, see [OGC API - Processes — Part 2 (DRU)](https://docs.ogc.org/DRAFTS/20-044.html#application-package-retrieval-operation).
+        """

--- a/gavicore/src/gavicore/models.py
+++ b/gavicore/src/gavicore/models.py
@@ -398,6 +398,9 @@ class ProcessSummary(DescriptionType):
     version: str
     """Process version number."""
 
+    mutable: bool | None = None
+    """Mutability of procses. This value is true for processes deployed dynamically to DRU-enabled servers."""
+
     jobControlOptions: list[JobControlOptions] | None = None
     """Available options to control process execution."""
 

--- a/gavicore/src/gavicore/models.py
+++ b/gavicore/src/gavicore/models.py
@@ -588,6 +588,186 @@ class JobResults(RootModel[dict[str, JobResult] | None]):
 
 
 # ---------------------------------------------------------------------
+#    OGC Application Package and Workflow descriptions
+# ---------------------------------------------------------------------
+
+
+class CWLDescription(BaseModel):
+    """
+    Possible encoding of an execution unit as CWL.
+    """
+
+    mediaType: Literal["application/cwl"]
+    """Media type used to identify the execution unit type. Must always be 'application/cwl'"""
+
+    value: str | None = None
+    # TODO: value points to https://raw.githubusercontent.com/common-workflow-language/cwl-v1.2/main/json-schema/cwl.yaml; object currently not modeled correctly
+    """JSON-encoded CWL document."""
+
+
+class ContainerConfig(OgcBaseModel):
+    """Hardware requirements and configuration properties for executing the process."""
+
+    cpuMin: int | None = Field(None, ge=1)
+    """Minimum number of CPUs required to run the process (unit is CPU core)."""
+
+    cpuMax: int | None = None
+    """Maximum number of CPU dedicated to the process (unit is CPU core)."""
+
+    memoryMin: int | float | None = None
+    """Minimum RAM memory required to run the application (unit is GB)."""
+
+    memoryMax: int | float | None = None
+    """Maximum RAM memory dedicated to the application (unit is GB)."""
+
+    storageTempMin: int | float | None = None
+    """ Minimum required temporary storage size (unit is GB)."""
+
+    storageOutputsMin: int | float | None = None
+    """Minimum required output storage size (unit is GB)."""
+
+    jobTimeout: int | float | None = None
+    """Timeout delay for a job execution (in seconds)."""
+
+
+class InputBinding(BaseModel):
+    """Defines how to specify the input for the execution unit.
+
+    . The value of various properties defined below can be expressions.
+      . The expression language SHALL be JavaScript(???).
+    . The "$(...)" syntax can be used to reference the current input or other
+        process inputs in an expression.
+        . The value "self" refers to the value of the current input.
+        . The value "inputs.<other_input>" refers to the value of another
+        process input.
+        . If the input is defined as a string of format "file" or "directory"
+        then the meta-values ".path", ".basename", ".nameroot" and ".nameext"
+        can be used to manipulate file or directory name without having to
+        resort to complex regular expressions.
+            . ".path" returns the path of a file name without the file name
+            . ".basename" returns the name of the file without the path
+            . ".nameroot" returns the basename without any extension
+            . ".nameext" returns the extension of the basename
+    """
+
+    prefix: str | None = None
+    """Command line prefix to add before the value."""
+
+    position: int | str | None = None
+    """
+    . The zero-based sorting key.
+    . The value can be an integer or a string.
+    . If the value is a string then it should be an expression that evaluates
+    to a single integer value or null.
+    """
+
+    valueFrom: str | None = None
+    """
+    . If valueFrom is a constant string value, use this as the value.
+    . If valueFrom is an expression, evaluate the expression to yield the
+    actual value to use to build the command line.
+    . If the value of the associated input parameter is null, valueFrom is
+    not evaluated and nothing is added to the command line.
+    """
+
+    itemSeparator: str | None = None
+    """ Join the array elements into a single string with the elements separated by itemSeparator."""
+
+    shellQuote: bool | None = None
+    """
+    . A Boolean that controls whether the value is quoted on the command.
+    . A value of true (or if shecllQuote is not provided) means that the
+    implementation SHALL not permit the interpretation of any shell
+    metacharacters or directives.
+    . A value of false should be used to inject metacharacters for operations
+    such as pipes.
+    """
+
+
+class OutputBinding(OgcBaseModel):
+    """Defines how to retrieve the output result from the command."""
+
+    glob: str | list[str] | None = None
+    """
+    . Wildcard pattern to find the output on disk or mounted volume.
+    . Uses UNIX "glob" wildcard patterns (see: "man 7 glob").
+    . See inputBinding.yaml (modeled as InputBinding) for referencing input values in an output
+      binding "glob" expression.
+    """
+
+
+class ContainerBindings(BaseModel):
+    """Input and output bindings of a container image execution unit."""
+
+    inputBindings: InputBinding | None = None
+    """Input bindings."""
+
+    outputBindings: OutputBinding | None = None
+    """Output bindings."""
+
+
+class ExecutionUnitContainer(OgcBaseModel):
+    """Execution unit described by a container image."""
+
+    image: str
+    """Container image reference for the execution unit."""
+
+    deployment: Literal["local", "remote", "hpc", "cloud"] | None = None
+    """Deployment information for the execution unit."""
+
+    config: ContainerConfig | None = None
+    """Optional configuration for image execution."""
+
+    bindings: ContainerBindings | None = None
+    """Binding properties for inputs and outputs."""
+
+
+class ContainerImage(BaseModel):
+    """The execute unit is a container image."""
+
+    type: Literal["docker", "oci"]
+    """Type of container image."""
+
+    value: ExecutionUnitContainer | None = None
+    """Description of container image"""
+
+
+class GenericExecutionUnit(BaseModel):
+    """A generic execution unit.
+
+    The standard notes:
+        The execution unit is not Docker/OCI or CWL and cannot be properly
+        described via the "mediaType" property of a qualified value
+        using an RFC 2046 media type (e.g. an "R" or "Python" script).
+        In this case a community-defined or custom token may be used
+        with the "type" property.
+    """
+
+    type: str
+    """Type of execution unit"""
+
+
+ExecutionUnitBase: TypeAlias = (
+    Link | CWLDescription | ContainerImage | GenericExecutionUnit
+)
+"""Execution unit encoding of a process."""
+
+
+class OGCApplicationPackage(BaseModel):
+    """
+    An OGC Application Package is a document that describes a process in sufficient detail so that an implementation of this Standard can dynamically deploy that process and make it accessible via an the processes API defined in "OGC API - Processes - Part 1: Core".
+
+    For more information, see: /req/ogcapppkg/schema
+    """
+
+    processDescription: ProcessDescription | None = None
+    """Process description of a given process."""
+
+    executionUnit: ExecutionUnitBase | list[ExecutionUnitBase]
+    """The execution unit of process."""
+
+
+# ---------------------------------------------------------------------
 #    Other
 # ---------------------------------------------------------------------
 

--- a/gavicore/src/gavicore/models.py
+++ b/gavicore/src/gavicore/models.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from abc import ABC
 from datetime import date
 from enum import Enum
-from typing import Any, Literal, TypeAlias, Annotated
+from typing import Any, Literal, TypeAlias
 
 from pydantic import AnyUrl, AwareDatetime, BaseModel, ConfigDict, Field, RootModel
 
@@ -399,7 +399,8 @@ class ProcessSummary(DescriptionType):
     """Process version number."""
 
     mutable: bool | None = None
-    """Mutability of procses. This value is true for processes deployed dynamically to DRU-enabled servers."""
+    """Mutability of process. This value is `True` for processes deployed
+    dynamically to DRU-enabled servers."""
 
     jobControlOptions: list[JobControlOptions] | None = None
     """Available options to control process execution."""
@@ -585,193 +586,6 @@ class JobResults(RootModel[dict[str, JobResult] | None]):
     """
 
     root: dict[str, JobResult] | None = None
-
-
-# ---------------------------------------------------------------------
-#    OGC Application Package and Workflow descriptions
-# ---------------------------------------------------------------------
-
-
-class CWLDescription(BaseModel):
-    """
-    Possible encoding of an execution unit as CWL.
-    """
-
-    media_type: Annotated[Literal["application/cwl"], Field(..., alias="mediaType")]
-    """Media type used to identify the execution unit type. Must always be 'application/cwl'."""
-
-    value: str | None = None
-    # TODO: value points to https://raw.githubusercontent.com/common-workflow-language/cwl-v1.2/main/json-schema/cwl.yaml; object currently not modeled correctly
-    """JSON-encoded CWL document."""
-
-
-class ContainerConfig(OgcBaseModel):
-    """Hardware requirements and configuration properties for executing the process."""
-
-    cpuMin: int | None = Field(None, ge=1)
-    """Minimum number of CPUs required to run the process (unit is CPU core)."""
-
-    cpuMax: int | None = None
-    """Maximum number of CPU dedicated to the process (unit is CPU core)."""
-
-    memoryMin: int | float | None = None
-    """Minimum RAM memory required to run the application (unit is GB)."""
-
-    memoryMax: int | float | None = None
-    """Maximum RAM memory dedicated to the application (unit is GB)."""
-
-    storageTempMin: int | float | None = None
-    """ Minimum required temporary storage size (unit is GB)."""
-
-    storageOutputsMin: int | float | None = None
-    """Minimum required output storage size (unit is GB)."""
-
-    jobTimeout: int | float | None = None
-    """Timeout delay for a job execution (in seconds)."""
-
-
-class InputBinding(BaseModel):
-    """Defines how to specify the input for the execution unit.
-
-    . The value of various properties defined below can be expressions.
-      . The expression language SHALL be JavaScript(???).
-    . The "$(...)" syntax can be used to reference the current input or other
-        process inputs in an expression.
-        . The value "self" refers to the value of the current input.
-        . The value "inputs.<other_input>" refers to the value of another
-        process input.
-        . If the input is defined as a string of format "file" or "directory"
-        then the meta-values ".path", ".basename", ".nameroot" and ".nameext"
-        can be used to manipulate file or directory name without having to
-        resort to complex regular expressions.
-            . ".path" returns the path of a file name without the file name
-            . ".basename" returns the name of the file without the path
-            . ".nameroot" returns the basename without any extension
-            . ".nameext" returns the extension of the basename
-    """
-
-    prefix: str | None = None
-    """Command line prefix to add before the value."""
-
-    position: int | str | None = None
-    """
-    . The zero-based sorting key.
-    . The value can be an integer or a string.
-    . If the value is a string then it should be an expression that evaluates
-    to a single integer value or null.
-    """
-
-    valueFrom: str | None = None
-    """
-    . If valueFrom is a constant string value, use this as the value.
-    . If valueFrom is an expression, evaluate the expression to yield the
-    actual value to use to build the command line.
-    . If the value of the associated input parameter is null, valueFrom is
-    not evaluated and nothing is added to the command line.
-    """
-
-    itemSeparator: str | None = None
-    """ Join the array elements into a single string with the elements separated by itemSeparator."""
-
-    shellQuote: bool | None = None
-    """
-    . A Boolean that controls whether the value is quoted on the command.
-    . A value of true (or if shecllQuote is not provided) means that the
-    implementation SHALL not permit the interpretation of any shell
-    metacharacters or directives.
-    . A value of false should be used to inject metacharacters for operations
-    such as pipes.
-    """
-
-
-class OutputBinding(OgcBaseModel):
-    """Defines how to retrieve the output result from the command."""
-
-    glob: str | list[str] | None = None
-    """
-    . Wildcard pattern to find the output on disk or mounted volume.
-    . Uses UNIX "glob" wildcard patterns (see: "man 7 glob").
-    . See inputBinding.yaml (modeled as InputBinding) for referencing input values in an output
-      binding "glob" expression.
-    """
-
-
-class ContainerBindings(BaseModel):
-    """Input and output bindings of a container image execution unit."""
-
-    inputBindings: InputBinding | None = None
-    """Input bindings."""
-
-    outputBindings: OutputBinding | None = None
-    """Output bindings."""
-
-
-class ExecutionUnitContainer(OgcBaseModel):
-    """Execution unit described by a container image."""
-
-    image: str
-    """Container image reference for the execution unit."""
-
-    deployment: Literal["local", "remote", "hpc", "cloud"] | None = None
-    """Deployment information for the execution unit."""
-
-    config: ContainerConfig | None = None
-    """Optional configuration for image execution."""
-
-    bindings: ContainerBindings | None = None
-    """Binding properties for inputs and outputs."""
-
-
-class ContainerImage(BaseModel):
-    """The execute unit is a container image."""
-
-    type: Literal["docker", "oci"]
-    """Type of container image."""
-
-    value: ExecutionUnitContainer | None = None
-    """Description of container image"""
-
-
-class GenericExecutionUnit(BaseModel):
-    """A generic execution unit.
-
-    The standard notes:
-        The execution unit is not Docker/OCI or CWL and cannot be properly
-        described via the "mediaType" property of a qualified value
-        using an RFC 2046 media type (e.g. an "R" or "Python" script).
-        In this case a community-defined or custom token may be used
-        with the "type" property.
-    """
-
-    type: str
-    """Type of execution unit"""
-
-
-ExecutionUnitBase: TypeAlias = (
-    Link | CWLDescription | ContainerImage | GenericExecutionUnit
-)
-"""Execution unit encoding of a process."""
-
-
-class OGCApplicationPackageProcessDescription(BaseModel):
-    """Wrapper around `ProcessDescription` to insert additional field name."""
-
-    process: ProcessDescription | None = None
-    """The process description."""
-
-
-class OGCApplicationPackage(BaseModel):
-    """
-    An OGC Application Package is a document that describes a process in sufficient detail so that an implementation of this Standard can dynamically deploy that process and make it accessible via an the processes API defined in "OGC API - Processes - Part 1: Core".
-
-    For more information, see: /req/ogcapppkg/schema
-    """
-
-    processDescription: OGCApplicationPackageProcessDescription | None = None
-    """Process description of a given process."""
-
-    executionUnit: ExecutionUnitBase | list[ExecutionUnitBase]
-    """The execution unit of process."""
 
 
 # ---------------------------------------------------------------------

--- a/gavicore/src/gavicore/models.py
+++ b/gavicore/src/gavicore/models.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from abc import ABC
 from datetime import date
 from enum import Enum
-from typing import Any, Literal, TypeAlias
+from typing import Any, Literal, TypeAlias, Annotated
 
 from pydantic import AnyUrl, AwareDatetime, BaseModel, ConfigDict, Field, RootModel
 
@@ -597,8 +597,8 @@ class CWLDescription(BaseModel):
     Possible encoding of an execution unit as CWL.
     """
 
-    mediaType: Literal["application/cwl"]
-    """Media type used to identify the execution unit type. Must always be 'application/cwl'"""
+    media_type: Annotated[Literal["application/cwl"], Field(..., alias="mediaType")]
+    """Media type used to identify the execution unit type. Must always be 'application/cwl'."""
 
     value: str | None = None
     # TODO: value points to https://raw.githubusercontent.com/common-workflow-language/cwl-v1.2/main/json-schema/cwl.yaml; object currently not modeled correctly

--- a/gavicore/src/gavicore/models.py
+++ b/gavicore/src/gavicore/models.py
@@ -753,6 +753,13 @@ ExecutionUnitBase: TypeAlias = (
 """Execution unit encoding of a process."""
 
 
+class OGCApplicationPackageProcessDescription(BaseModel):
+    """Wrapper around `ProcessDescription` to insert additional field name."""
+
+    process: ProcessDescription | None = None
+    """The process description."""
+
+
 class OGCApplicationPackage(BaseModel):
     """
     An OGC Application Package is a document that describes a process in sufficient detail so that an implementation of this Standard can dynamically deploy that process and make it accessible via an the processes API defined in "OGC API - Processes - Part 1: Core".
@@ -760,7 +767,7 @@ class OGCApplicationPackage(BaseModel):
     For more information, see: /req/ogcapppkg/schema
     """
 
-    processDescription: ProcessDescription | None = None
+    processDescription: OGCApplicationPackageProcessDescription | None = None
     """Process description of a given process."""
 
     executionUnit: ExecutionUnitBase | list[ExecutionUnitBase]

--- a/gavicore/tests/test_dru_models.py
+++ b/gavicore/tests/test_dru_models.py
@@ -1,0 +1,45 @@
+#  Copyright (c) 2025-2026 by the Eozilla team and contributors
+#  Permissions are hereby granted under the terms of the Apache 2.0 License:
+#  https://opensource.org/license/apache-2-0.
+
+import inspect
+from typing import TypeVar
+from unittest import TestCase
+
+from pydantic import BaseModel
+
+import gavicore.dru_models as m
+
+REQUIRED_CLASSES = {
+    "OGCApplicationPackage",
+    "OGCApplicationPackageProcessDescription",
+    "CWLDescription",
+    "ContainerImage",
+    "ExecutionUnitContainer",
+    "ContainerConfig",
+    "ContainerBindings",
+    "InputBinding",
+    "OutputBinding",
+    "GenericExecutionUnit",
+}
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class DRUModelsTest(TestCase):
+    def test_classes(self):
+        all_classes = set(
+            name
+            for name, obj in inspect.getmembers(m, inspect.isclass)
+            if issubclass(obj, BaseModel)
+        )
+        self.assertSetIsOk(REQUIRED_CLASSES, all_classes)
+
+    def assertSetIsOk(self, required: set[str], actual: set[str]):
+        contained_items = set(c for c in required if c in actual)
+        self.assertSetEqual(required, contained_items, "contained")
+
+    def test_models_have_repr_json(self):
+        for name, obj in inspect.getmembers(m, inspect.isclass):
+            if name in REQUIRED_CLASSES and issubclass(obj, BaseModel):
+                self.assertTrue(hasattr(obj, "_repr_json_"), msg=f"model {name}")

--- a/gavicore/tests/test_dru_service.py
+++ b/gavicore/tests/test_dru_service.py
@@ -1,0 +1,27 @@
+#  Copyright (c) 2025-2026 by the Eozilla team and contributors
+#  Permissions are hereby granted under the terms of the Apache 2.0 License:
+#  https://opensource.org/license/apache-2-0.
+
+import inspect
+from unittest import TestCase
+
+from gavicore.dru_service import DRUService
+
+from .test_service import REQUIRED_METHODS
+
+REQUIRED_DRU_METHODS = {
+    "deploy_process",
+    "replace_process",
+    "undeploy_process",
+    "get_formal_description",
+}
+
+REQUIRED_DRU_METHODS |= REQUIRED_METHODS
+
+
+class DRUServiceTest(TestCase):
+    def test_methods(self):
+        all_method_names = set(
+            name for name, obj in inspect.getmembers(DRUService, inspect.isfunction)
+        )
+        self.assertSetEqual(REQUIRED_DRU_METHODS, set(all_method_names))

--- a/gavicore/tests/test_dru_service.py
+++ b/gavicore/tests/test_dru_service.py
@@ -7,7 +7,7 @@ from unittest import TestCase
 
 from gavicore.dru_service import DRUService
 
-from .test_service import REQUIRED_METHODS
+from .test_service import REQUIRED_METHODS as REQUIRED_SERVICE_METHODS
 
 REQUIRED_DRU_METHODS = {
     "deploy_process",
@@ -16,7 +16,7 @@ REQUIRED_DRU_METHODS = {
     "get_formal_description",
 }
 
-REQUIRED_DRU_METHODS |= REQUIRED_METHODS
+REQUIRED_DRU_METHODS |= REQUIRED_SERVICE_METHODS
 
 
 class DRUServiceTest(TestCase):

--- a/gavicore/tests/test_models.py
+++ b/gavicore/tests/test_models.py
@@ -35,16 +35,6 @@ REQUIRED_CLASSES = {
     "ProcessRequest",
     "ProcessSummary",
     "Schema",
-    "CWLDescription",
-    "ContainerConfig",
-    "InputBinding",
-    "OutputBinding",
-    "ContainerBindings",
-    "ExecutionUnitContainer",
-    "ContainerImage",
-    "GenericExecutionUnit",
-    "OGCApplicationPackageProcessDescription",
-    "OGCApplicationPackage",
 }
 
 T = TypeVar("T", bound=BaseModel)

--- a/gavicore/tests/test_models.py
+++ b/gavicore/tests/test_models.py
@@ -35,6 +35,16 @@ REQUIRED_CLASSES = {
     "ProcessRequest",
     "ProcessSummary",
     "Schema",
+    "CWLDescription",
+    "ContainerConfig",
+    "InputBinding",
+    "OutputBinding",
+    "ContainerBindings",
+    "ExecutionUnitContainer",
+    "ContainerImage",
+    "GenericExecutionUnit",
+    "OGCApplicationPackageProcessDescription",
+    "OGCApplicationPackage",
 }
 
 T = TypeVar("T", bound=BaseModel)


### PR DESCRIPTION
This PR adds an initial DRUService interface and extends pydantic models according to the OGC API - Processes part 2 draft specification. 

Checklist (strike out non-applicable):

~~* [ ] Changes documented in `CHANGES.md`~~
~~* [ ] Related issue exists and is referred to in the PR description and `CHANGES.md`~~
* [x] Added docstrings and API docs for any new/modified user-facing classes and functions
* [x] Changes/features documented in `docs/*`
* [x] Unit-tests adapted/added for changes/features 
* [x] Test coverage remains or increases (target 100%)
