### PR TITLE
Added the CWL subset supported by Eozilla as pydantic models

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+## Changes in version 0.2.0 (in development)
+
+### Enhancements
+
+- Added the CWL subset supported by Eozilla as pydantic models in new 
+  module `gavicore.cwl.models`.
+
+
 ## Changes in version 0.1.2 (in development)
 
 ### Enhancements

--- a/gavicore/src/gavicore/cwl/__init__.py
+++ b/gavicore/src/gavicore/cwl/__init__.py
@@ -1,0 +1,4 @@
+#  Copyright (c) 2026 by the Eozilla team and contributors
+#  Permissions are hereby granted under the terms of the Apache 2.0 License:
+#  https://opensource.org/license/apache-2-0.
+

--- a/gavicore/src/gavicore/cwl/models.py
+++ b/gavicore/src/gavicore/cwl/models.py
@@ -4,6 +4,47 @@ from typing import Any, Literal, TypeAlias
 
 from pydantic import BaseModel, ConfigDict, Field, RootModel, model_validator
 
+"""Pydantic models for a deliberately small CWL subset.
+
+This module models the part of CWL that is useful for deploying simple
+containerized processes through OGC API - Processes Part 2: Deploy, Replace,
+Update.
+
+The goal is not to implement CWL as a general workflow language or to provide a
+complete CWL runner. Instead, CWL is treated as a deployment description format:
+it describes a command-line tool, its container image, its inputs, its outputs,
+and the basic command-line bindings needed to execute it.
+
+Supported concepts include:
+
+* `CommandLineTool`
+* `cwlVersion: v1.0`
+* `baseCommand`
+* `DockerRequirement`
+* primitive input types
+* `File` and `Directory`
+* optional types such as `string?`
+* arrays
+* enums
+* defaults
+* `label` and `doc`
+* basic `inputBinding`
+* basic `outputBinding.glob`
+
+This subset is intentionally restrictive. It excludes features that would require
+a substantially more complex CWL execution engine, such as workflows, scatter,
+sub-workflows, JavaScript expressions, `valueFrom`, `outputEval`, dynamic runtime
+expressions, and step-level input expressions.
+
+For an OGC API - Processes Part 2 server, this is usually the more useful
+boundary: the server can import a CWL document into its own internal process
+model, publish the corresponding process description, and execute the referenced
+container with validated inputs. More advanced CWL features can be added later,
+but they should be treated as explicit extensions rather than assumed support for
+the full CWL specification.
+"""
+
+
 CwlVersion: TypeAlias = Literal["v1.0"]
 CommandLineToolClass: TypeAlias = Literal["CommandLineTool"]
 

--- a/gavicore/src/gavicore/cwl/models.py
+++ b/gavicore/src/gavicore/cwl/models.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from typing import Any, Literal, TypeAlias
+
+from pydantic import BaseModel, ConfigDict, Field, RootModel, model_validator
+
+CwlVersion: TypeAlias = Literal["v1.0"]
+CommandLineToolClass: TypeAlias = Literal["CommandLineTool"]
+
+
+class CwlBaseModel(BaseModel):
+    """Base model for the supported CWL subset."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+
+class DockerRequirement(CwlBaseModel):
+    """Subset of CWL DockerRequirement."""
+
+    docker_pull: str = Field(alias="dockerPull")
+
+
+class Requirements(CwlBaseModel):
+    """Supported CWL requirements."""
+
+    docker_requirement: DockerRequirement = Field(alias="DockerRequirement")
+
+
+class InputBinding(CwlBaseModel):
+    """Subset of CWL inputBinding."""
+
+    prefix: str | None = None
+    separate: bool | None = None
+
+
+class OutputBinding(CwlBaseModel):
+    """Subset of CWL outputBinding."""
+
+    glob: str
+
+
+class EnumType(CwlBaseModel):
+    """Inline CWL enum type."""
+
+    type: Literal["enum"]
+    symbols: list[str]
+
+
+class ArrayType(CwlBaseModel):
+    """Inline CWL array type."""
+
+    type: Literal["array"]
+    items: SupportedType
+
+
+PrimitiveTypeName: TypeAlias = Literal[
+    "string", "int", "long", "float", "double", "boolean"
+]
+FileSystemTypeName: TypeAlias = Literal["File", "Directory"]
+ScalarTypeName: TypeAlias = PrimitiveTypeName | FileSystemTypeName
+
+SupportedType: TypeAlias = ScalarTypeName | EnumType | ArrayType
+
+
+class CwlType(RootModel[SupportedType]):
+    """Root wrapper for a supported CWL type expression."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_optional_type(cls, value: Any) -> Any:
+        if isinstance(value, str) and value.endswith("?"):
+            return value[:-1]
+        return value
+
+    @property
+    def is_file(self) -> bool:
+        return self.root == "File"
+
+    @property
+    def is_directory(self) -> bool:
+        return self.root == "Directory"
+
+    @property
+    def is_array(self) -> bool:
+        return isinstance(self.root, ArrayType)
+
+    @property
+    def is_enum(self) -> bool:
+        return isinstance(self.root, EnumType)
+
+
+class InputParameter(CwlBaseModel):
+    """Supported subset of a CWL input parameter."""
+
+    type: CwlType
+    label: str | None = None
+    doc: str | None = None
+    default: Any | None = None
+    input_binding: InputBinding | None = Field(default=None, alias="inputBinding")
+
+    @property
+    def required(self) -> bool:
+        return self.default is None
+
+
+class OutputParameter(CwlBaseModel):
+    """Supported subset of a CWL output parameter."""
+
+    type: CwlType
+    label: str | None = None
+    doc: str | None = None
+    output_binding: OutputBinding = Field(alias="outputBinding")
+
+
+class Inputs(RootModel[dict[str, InputParameter]]):
+    pass
+
+
+class Outputs(RootModel[dict[str, OutputParameter]]):
+    pass
+
+
+class CommandLineTool(CwlBaseModel):
+    """Entry-point class for the supported CWL CommandLineTool subset."""
+
+    cwl_version: CwlVersion = Field(alias="cwlVersion")
+    class_: CommandLineToolClass = Field(alias="class")
+    label: str | None = None
+    doc: str | None = None
+    base_command: str | list[str] = Field(alias="baseCommand")
+    requirements: Requirements
+    inputs: Inputs
+    outputs: Outputs
+
+    @model_validator(mode="after")
+    def reject_unsupported_runtime_features(self) -> "CommandLineTool":
+        # The ConfigDict(extra="forbid") already rejects unknown fields such as
+        # valueFrom, outputEval, scatter, steps, hints, arguments, etc.
+        # This method exists as the explicit policy hook for future checks.
+        return self
+
+
+CwlDocument = CommandLineTool

--- a/gavicore/src/gavicore/cwl/models.py
+++ b/gavicore/src/gavicore/cwl/models.py
@@ -1,3 +1,7 @@
+#  Copyright (c) 2026 by the Eozilla team and contributors
+#  Permissions are hereby granted under the terms of the Apache 2.0 License:
+#  https://opensource.org/license/apache-2-0.
+
 from __future__ import annotations
 
 from typing import Any, Literal, TypeAlias

--- a/gavicore/tests/cwl/__init__.py
+++ b/gavicore/tests/cwl/__init__.py
@@ -1,0 +1,4 @@
+#  Copyright (c) 2026 by the Eozilla team and contributors
+#  Permissions are hereby granted under the terms of the Apache 2.0 License:
+#  https://opensource.org/license/apache-2-0.
+

--- a/gavicore/tests/cwl/test_models.py
+++ b/gavicore/tests/cwl/test_models.py
@@ -1,3 +1,7 @@
+#  Copyright (c) 2026 by the Eozilla team and contributors
+#  Permissions are hereby granted under the terms of the Apache 2.0 License:
+#  https://opensource.org/license/apache-2-0.
+
 from __future__ import annotations
 
 import yaml

--- a/gavicore/tests/cwl/test_models.py
+++ b/gavicore/tests/cwl/test_models.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import yaml
+
+from gavicore.cwl.models import CommandLineTool
+
+NDVI_CWL = """
+cwlVersion: v1.0
+class: CommandLineTool
+
+label: Compute NDVI
+doc: Computes an NDVI raster from Sentinel-2 bands.
+
+baseCommand:
+  - ndvi
+
+requirements:
+  DockerRequirement:
+    dockerPull: ghcr.io/acme/ndvi:1.2
+
+inputs:
+  nir:
+    type: File
+    inputBinding:
+      prefix: --nir
+
+  red:
+    type: File
+    inputBinding:
+      prefix: --red
+
+  output_format:
+    type: string?
+    default: GeoTIFF
+    inputBinding:
+      prefix: --format
+
+outputs:
+  ndvi:
+    type: File
+    outputBinding:
+      glob: "*.tif"
+"""
+
+
+ZONAL_STATS_CWL = """
+cwlVersion: v1.0
+class: CommandLineTool
+
+label: Zonal Statistics
+
+baseCommand:
+  - zonalstats
+
+requirements:
+  DockerRequirement:
+    dockerPull: ghcr.io/acme/zonalstats:2.0
+
+inputs:
+  raster:
+    type: File
+    inputBinding:
+      prefix: --raster
+
+  polygons:
+    type: File
+    inputBinding:
+      prefix: --polygons
+
+  statistics:
+    type:
+      type: array
+      items:
+        type: enum
+        symbols:
+          - mean
+          - min
+          - max
+          - median
+    inputBinding:
+      prefix: --stat
+      separate: true
+
+outputs:
+  table:
+    type: File
+    outputBinding:
+      glob: "*.csv"
+"""
+
+
+def parse_cwl(text: str) -> CommandLineTool:
+    data = yaml.safe_load(text)
+    return CommandLineTool.model_validate(data)
+
+
+def test_parse_ndvi_cwl() -> None:
+    doc = parse_cwl(NDVI_CWL)
+
+    assert doc.cwl_version == "v1.0"
+    assert doc.class_ == "CommandLineTool"
+    assert doc.label == "Compute NDVI"
+    assert doc.requirements.docker_requirement.docker_pull == "ghcr.io/acme/ndvi:1.2"
+    assert doc.inputs.root["nir"].type.is_file
+    assert doc.inputs.root["red"].type.is_file
+    assert doc.inputs.root["output_format"].default == "GeoTIFF"
+    assert doc.outputs.root["ndvi"].output_binding.glob == "*.tif"
+
+
+def test_parse_zonal_stats_cwl() -> None:
+    doc = parse_cwl(ZONAL_STATS_CWL)
+
+    statistics = doc.inputs.root["statistics"].type.root
+
+    assert doc.label == "Zonal Statistics"
+    assert (
+        doc.requirements.docker_requirement.docker_pull == "ghcr.io/acme/zonalstats:2.0"
+    )
+    assert statistics.type == "array"
+    assert statistics.items.type == "enum"
+    assert statistics.items.symbols == ["mean", "min", "max", "median"]
+    assert doc.outputs.root["table"].output_binding.glob == "*.csv"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "eozilla"
-version = "0.1.2.dev0"
+version = "0.2.0.dev0"
 description = "A suite of tools around workflow orchestration systems and the OGC API - Processes"
 requires-python = ">=3.11"
 


### PR DESCRIPTION
## Summary

Pydantic models for a deliberately small CWL subset.

The new module `gavicore.cwl.modules` models the part of CWL that is useful for deploying simple
containerized processes through OGC API - Processes Part 2: Deploy, Replace, Update.

The goal is not to implement CWL as a general workflow language or to provide a
complete CWL runner. Instead, CWL is treated as a deployment description format:
it describes a command-line tool, its container image, its inputs, its outputs,
and the basic command-line bindings needed to execute it.

Supported concepts include:

- CommandLineTool
- cwlVersion: v1.0
- baseCommand
- DockerRequirement
- primitive input types
- File and Directory
- optional types such as string?
- arrays
- enums
- defaults
- label and doc
- basic inputBinding
- basic outputBinding.glob

This subset is intentionally restrictive. It excludes features that would require
a substantially more complex CWL execution engine, such as workflows, scatter,
subworkflows, JavaScript expressions, valueFrom, outputEval, dynamic runtime
expressions, and step-level input expressions.

For an OGC API - Processes Part 2 server, this is usually the more useful
boundary: the server can import a CWL document into its own internal process
model, publish the corresponding process description, and execute the referenced
container with validated inputs. More advanced CWL features can be added later,
but they should be treated as explicit extensions rather than assumed support for
the full CWL specification.


Checklist (strike out non-applicable):

* [x] Changes documented in `CHANGES.md`
* [ ] Related issue exists and is referred to in the PR description and `CHANGES.md`
* [x] Added docstrings and API docs for any new/modified user-facing classes and functions
* [x] Changes/features documented in `docs/*`
* [x] Unit-tests adapted/added for changes/features 
* [x] Test coverage remains or increases (target 100%)
