### PR TITLE
Deprecate legacy GUI

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,19 +2,18 @@
 
 ### Enhancements
 
-
-- **Appligator** now supports node selectors and tolerations for generated pods via
-  `--node-selector key=value` and `--toleration key:operator[:value[:effect]]` CLI
-  options (both repeatable and configurable via `appligator-config.yaml`).
+- **Appligator** enhancements:
+  - It now supports node selectors and tolerations for generated pods via
+    `--node-selector key=value` and `--toleration key:operator[:value[:effect]]` CLI
+    options (both repeatable and configurable via `appligator-config.yaml`).
+  - In `run_step.py`: function resolution now delegates to
+    `gavicore.util.dynimp.import_value` for consistent dynamic-import error
+    handling, keeping only the procodile-specific Workflow-registry fallback as
+    bespoke logic.
+  - Updated Appligator documentation accordingly.
 - Added `ImageOpener` to **Cuiman**'s job result opener framework, supporting
   all PIL-compatible image formats from both local paths and S3-compatible
   object storage (via the optional `s3fs` package).
-- **Cuiman** has a new experimental, alternative GUI - the Eozilla app. 
-  The app is a native React app that doesn't require 
-  the `panel` library anymore. (#124)
-  - Added a new client method `show_app()` and new property `app_store` to interact 
-    with the app's data state. Renders the app in a notebook cell or a new browser tab.
-  - Added a new CLI command `cuiman show-app`. Opens the app in a new browser tab.
 
 ### Fixes
 
@@ -24,12 +23,17 @@
 
 ### Other changes
 
-- Deprecated the legacy `cuiman.gui` notebook UI, `schema2ui`, and the
-  GUI-only `ClientConfig.accept_process()`, `accept_input()`, and
-  `is_advanced_input()` hooks on the `maintenance/0.1.x` branch. These
-  legacy APIs remain available there, but they will not work in newer
-  Eozilla versions.
-- Updated appligator docs.
+For upcoming **Cuiman 0.2.0** we decided to no longer use the `panel` library
+for the Cuiman GUI. Therefore, the following items have been deprecated and will 
+be removed in Eozilla 0.2.0:
+
+- the `gavicore.ui` package and the `schema2ui` tool,
+- the `cuiman.gui` package,
+- the `ClientConfig` hook methods,
+  - `accept_process()`, 
+  - `accept_input()`, and
+  - `is_advanced_input()`. 
+
 
 ## Changes in version 0.1.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,11 @@
 
 ### Other changes
 
+- Deprecated the legacy `cuiman.gui` notebook UI, `schema2ui`, and the
+  GUI-only `ClientConfig.accept_process()`, `accept_input()`, and
+  `is_advanced_input()` hooks on the `maintenance/0.1.x` branch. These
+  legacy APIs remain available there, but they will not work in newer
+  Eozilla versions.
 - Updated appligator docs.
 
 ## Changes in version 0.1.1

--- a/cuiman/src/cuiman/api/config.py
+++ b/cuiman/src/cuiman/api/config.py
@@ -16,6 +16,7 @@ from typing import (
 import yaml
 from pydantic import Field, HttpUrl, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from typing_extensions import deprecated
 
 from gavicore.models import InputDescription, ProcessDescription, ProcessSummary
 from gavicore.ui import FieldFactoryRegistry, FieldMeta
@@ -156,6 +157,10 @@ class ClientConfig(AuthConfig, BaseSettings):
 
     # noinspection PyUnusedLocal
     @classmethod
+    @deprecated(
+        "ClientConfig.accept_process() is deprecated, only used by the legacy "
+        "cuiman.gui client, and will not work in newer Eozilla versions."
+    )
     def accept_process(
         cls, process_summary: ProcessSummary, **filter_kwargs: Any
     ) -> bool:
@@ -183,6 +188,10 @@ class ClientConfig(AuthConfig, BaseSettings):
 
     # noinspection PyUnusedLocal
     @classmethod
+    @deprecated(
+        "ClientConfig.accept_input() is deprecated, only used by the legacy "
+        "cuiman.gui client, and will not work in newer Eozilla versions."
+    )
     def accept_input(
         cls,
         process_description: ProcessDescription,
@@ -217,6 +226,10 @@ class ClientConfig(AuthConfig, BaseSettings):
 
     # noinspection PyUnusedLocal
     @classmethod
+    @deprecated(
+        "ClientConfig.is_advanced_input() is deprecated, only used by the legacy "
+        "cuiman.gui client, and will not work in newer Eozilla versions."
+    )
     def is_advanced_input(
         cls,
         process_description: ProcessDescription,

--- a/cuiman/src/cuiman/gui/client.py
+++ b/cuiman/src/cuiman/gui/client.py
@@ -7,6 +7,7 @@ import time
 from typing import Any, Optional
 
 import panel as pn
+from typing_extensions import deprecated
 
 from cuiman.api.client import Client as ApiClient
 from cuiman.api.config import ClientConfig
@@ -17,6 +18,10 @@ from gavicore.models import ProcessList
 from .jobs_event_bus import JobsEventBus
 
 
+@deprecated(
+    "cuiman.gui.Client is deprecated, depends on the legacy notebook GUI, "
+    "and will not work in newer Eozilla versions."
+)
 class Client(ApiClient):
     def __init__(
         self,
@@ -33,6 +38,10 @@ class Client(ApiClient):
     def _reset_state(self):
         self._update_thread = None
 
+    @deprecated(
+        "Client.show() is deprecated, only supports the legacy cuiman.gui "
+        "notebook UI, and will not work in newer Eozilla versions."
+    )
     def show(self, **kwargs: Any):
         """Shows the client's main GUI.
 
@@ -69,6 +78,10 @@ class Client(ApiClient):
         self._ensure_update_thread_is_running()
         return main_panel
 
+    @deprecated(
+        "Client.show_jobs() is deprecated, only supports the legacy cuiman.gui "
+        "notebook UI, and will not work in newer Eozilla versions."
+    )
     def show_jobs(self) -> pn.viewable.Viewer:
         from .panels import JobsPanelView, JobsPanelViewModel
 
@@ -84,6 +97,10 @@ class Client(ApiClient):
         self._jobs_event_bus.register(view_model)
         return JobsPanelView(view_model)
 
+    @deprecated(
+        "Client.show_job() is deprecated, only supports the legacy cuiman.gui "
+        "notebook UI, and will not work in newer Eozilla versions."
+    )
     def show_job(self, job_id: str):
         from .panels import JobInfoPanelView
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -79,6 +79,10 @@ client.show()
 client.show_jobs()
 ```
 
+The `cuiman.gui` notebook UI shown above is deprecated and only kept on the
+`maintenance/0.1.x` branch for existing users. It will not work in newer
+Eozilla versions.
+
 Run Eozilla client CLI
 
 ```commandline

--- a/docs/cuiman/gui-generation.md
+++ b/docs/cuiman/gui-generation.md
@@ -1,5 +1,11 @@
 # Cuiman GUI-Generation 
 
+!!! warning
+    This document describes Cuiman's legacy notebook GUI based on `cuiman.gui`
+    and `gavicore.ui`. It remains available on the `maintenance/0.1.x` branch
+    for existing users, but it is deprecated and will not work in newer
+    Eozilla versions.
+
 The Cuiman GUI to build process requests is generated from a selected 
 [OGC process descriptions](https://docs.ogc.org/is/18-062r2/18-062r2.html#toc35).
 For a given process, the input descriptions are used to build an 

--- a/docs/cuiman/index.md
+++ b/docs/cuiman/index.md
@@ -6,6 +6,7 @@ The Eozilla _Cuiman_ tool provides a client for servers compliant with the
 It comprises the following interfaces:
 
 - [Cuiman Python API](../notebooks/cuiman-api.ipynb)
-- [Cuiman GUI](../notebooks/cuiman-gui.ipynb)
+- [Cuiman GUI](../notebooks/cuiman-gui.ipynb) (deprecated legacy interface; it
+  remains available on the `maintenance/0.1.x` branch, but will not work in
+  newer Eozilla versions)
 - [Cuiman CLI](../notebooks/cuiman-cli.ipynb)
-

--- a/docs/gavicore/ui/description.md
+++ b/docs/gavicore/ui/description.md
@@ -1,5 +1,10 @@
 # `gavicore.ui` Description
 
+!!! warning
+    `gavicore.ui` and its Panel-based `schema2ui` workflow are deprecated.
+    They remain available on the `maintenance/0.1.x` branch for existing users,
+    but they will not work in newer Eozilla versions.
+
 The `gavicore.ui` package contains the code to generate widgets and panels 
 
 - from plain OpenAPI Schema instances of type [Schema][gavicore.models.Schema], 

--- a/gavicore/src/gavicore/ui/panel/schema2ui.py
+++ b/gavicore/src/gavicore/ui/panel/schema2ui.py
@@ -9,6 +9,7 @@ from typing import Annotated, Any
 import panel as pn
 import typer
 import yaml
+from typing_extensions import deprecated
 
 from gavicore.models import Schema
 from gavicore.ui import FieldFactoryRegistry, FieldMeta
@@ -26,6 +27,10 @@ app = typer.Typer()
 
 
 @app.command(name=APP_NAME)
+@deprecated(
+    "schema2ui is deprecated, only supports the legacy Panel-based UI generator, "
+    "and will not work in newer Eozilla versions."
+)
 def main(
     schema_path: Annotated[
         str,
@@ -38,6 +43,10 @@ def main(
     schemas_to_ui(schema_path)
 
 
+@deprecated(
+    "schemas_to_ui() is deprecated, only supports the legacy Panel-based UI "
+    "generator, and will not work in newer Eozilla versions."
+)
 def schemas_to_ui(
     *schema_paths: str,
     registry: FieldFactoryRegistry["PanelField"] | None = None,


### PR DESCRIPTION
Deprecate the legacy cuiman.gui / gavicore.ui workflow on the maintenance/0.1.x branch while keeping it available for existing users. Add `typing_extensions.deprecated` warnings to the old GUI entry points, `schema2ui`, and the GUI-specific ClientConfig hooks `accept_process()`, `accept_input()`, and `is_advanced_input()`, with messages clarifying that this legacy path will not work in newer Eozilla versions. Update the documentation accordingly.

Checklist (strike out non-applicable):

  - [x] Changes documented in CHANGES.md
  - [x] Related issue exists and is referred to in the PR description and CHANGES.md
  - [x] Added docstrings and API docs for any new/modified user-facing classes and functions
  - [x] Changes/features documented in docs/*
  - [x] Unit-tests adapted/added for changes/features
  - [x] Test coverage remains or increases (target 100%)