### PR TITLE
Pin typer >=0.26, no more click

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 ### Other changes
 
+- We require `typer >=0.26` and no longer depend on `click`. 
+  See https://typer.tiangolo.com/tutorial/click/.
 - Fixed typing in `gavicore.uitil.cli.AliasedGroup` wrt `typer >=0.26.8`.
 - GitHub CI is now also performed for branches named `feature/**`.
 

--- a/appligator/pyproject.toml
+++ b/appligator/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
   "pyyaml",
   "tomli-w",
   "tomli; python_version < '3.11'",
-  "typer",
+  "typer >=0.26.0,<1",
   # local dependency
   "gavicore >=0.2.0.dev0",
   "procodile >=0.2.0.dev0",

--- a/cuiman/pyproject.toml
+++ b/cuiman/pyproject.toml
@@ -40,12 +40,11 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-  "click",
   "pydantic",
   "pydantic-settings",
   "pyyaml",
   "remotestate >=0.3.1,<1",
-  "typer",
+  "typer >=0.26.0,<1",
   "uri-template",
   "httpx",
   # local dependency

--- a/cuiman/src/cuiman/cli/cli.py
+++ b/cuiman/src/cuiman/cli/cli.py
@@ -6,9 +6,6 @@ from typing import Annotated, Final, Optional
 
 import typer.core
 
-# noinspection PyProtectedMember
-from typer._click import exceptions as click_exceptions
-
 from cuiman.api.auth.config import AUTH_TYPE_NAMES
 from cuiman.cli.output import OutputFormat
 from gavicore.util.cli.group import AliasedGroup
@@ -145,7 +142,11 @@ def new_cli(
             from cuiman import Client
             from cuiman.cli.config import get_config
 
-            config = get_config(config_path)
+            try:
+                config = get_config(config_path)
+            except ValueError as exc:
+                typer.echo(str(exc), err=True)
+                raise typer.Exit(code=1) from exc
             # "pragma: no cover" is here because coverage reports
             # the next line as uncovered, but that's definitely no true.
             return Client(config=config)  # pragma: no cover
@@ -245,23 +246,26 @@ def new_cli(
         from .config import configure_client_with_prompt
 
         if auth_type is not None and auth_type not in AUTH_TYPE_NAMES:
-            raise click_exceptions.ClickException(
-                f"Invalid authentication type: {auth_type}"
-            )
+            typer.echo(f"Invalid authentication type: {auth_type}", err=True)
+            raise typer.Exit(code=1)
 
-        config_path = configure_client_with_prompt(
-            config_path=config_file,
-            api_url=api_url,
-            auth_type=auth_type,  # type: ignore[arg-type]
-            auth_url=auth_url,
-            client_id=client_id,
-            client_secret=client_secret,
-            username=username,
-            password=password,
-            token=token,
-            use_bearer=use_bearer,
-            token_header=token_header,
-        )
+        try:
+            config_path = configure_client_with_prompt(
+                config_path=config_file,
+                api_url=api_url,
+                auth_type=auth_type,  # type: ignore[arg-type]
+                auth_url=auth_url,
+                client_id=client_id,
+                client_secret=client_secret,
+                username=username,
+                password=password,
+                token=token,
+                use_bearer=use_bearer,
+                token_header=token_header,
+            )
+        except ValueError as exc:
+            typer.echo(str(exc), err=True)
+            raise typer.Exit(code=1) from exc
         typer.echo(f"Client configuration written to {config_path}")
 
     @t.command()

--- a/cuiman/src/cuiman/cli/config.py
+++ b/cuiman/src/cuiman/cli/config.py
@@ -6,7 +6,6 @@ import os
 from pathlib import Path
 from typing import Any
 
-import click
 import typer
 from pydantic import BaseModel
 
@@ -20,14 +19,11 @@ def get_config(config_path: Path | str | None) -> ClientConfig:
     file_config = ClientConfig.from_file(config_path=config_path)
     if file_config is None:
         if config_path is None:
-            raise click.ClickException(
-                "The client tool has not yet been configured;"
-                " please use the 'configure' command to set it up."
+            raise ValueError(
+                "The client tool has not yet been configured; "
+                "please use the 'configure' command to set it up."
             )
-        else:
-            raise click.ClickException(
-                f"Configuration file {config_path} not found or empty."
-            )
+        raise ValueError(f"Configuration file {config_path} not found or empty.")
     return ClientConfig.create(config=file_config)
 
 
@@ -54,13 +50,7 @@ def configure_client_with_prompt(
 
     # TODO: add URL validator
     _prompt_for_str(ctx, "api_url", "Process API URL", DEFAULT_API_URL)
-    auth_type = _prompt_for_str(
-        ctx,
-        "auth_type",
-        "API authorisation type",
-        DEFAULT_AUTH_TYPE,
-        choice=click.Choice(AUTH_TYPE_NAMES, case_sensitive=False),
-    )
+    auth_type = _prompt_for_auth_type(ctx)
     if auth_type and auth_type != "none":
         _configure_auth_with_prompt(ctx, auth_type)
 
@@ -123,15 +113,28 @@ def _configure_token_type_with_prompt(ctx: _Context) -> None:
         _prompt_for_str(ctx, "token_header", "Access token header", "X-Auth-Token")
 
 
-def _prompt_for_str(
-    ctx: _Context, key: str, text: str, default: str, choice: click.Choice | None = None
-) -> str:
+def _prompt_for_auth_type(ctx: _Context) -> str:
+    auth_type = _prompt_for_str(
+        ctx,
+        "auth_type",
+        f"API authorisation type ({'|'.join(AUTH_TYPE_NAMES)})",
+        DEFAULT_AUTH_TYPE,
+    ).casefold()
+    if auth_type not in AUTH_TYPE_NAMES:
+        raise ValueError(
+            f"Invalid authentication type: {auth_type}. "
+            f"Expected one of: {', '.join(AUTH_TYPE_NAMES)}."
+        )
+    return auth_type
+
+
+def _prompt_for_str(ctx: _Context, key: str, text: str, default: str) -> str:
     value: str | None = ctx.cli_params.get(key)
     if value is None:
         value = (
             typer.prompt(
                 text,
-                type=choice or str,
+                type=str,
                 default=ctx.prev_params.get(key) or default,
             )
             or ""

--- a/cuiman/tests/cli/test_cli.py
+++ b/cuiman/tests/cli/test_cli.py
@@ -108,6 +108,15 @@ class CliTest(TestCase):
         if config_path.exists():
             config_path.unlink()
 
+    @patch("cuiman.cli.config.configure_client_with_prompt")
+    def test_configure_with_configuration_error(self, mock_configure):
+        mock_configure.side_effect = ValueError("bad config")
+
+        result = invoke_cli("configure")
+
+        self.assertEqual(1, result.exit_code, msg=self.get_result_msg(result))
+        self.assertEqual("bad config\n", result.stderr)
+
     def test_get_processes(self):
         result = invoke_cli("list-processes")
         self.assertEqual(0, result.exit_code, msg=self.get_result_msg(result))
@@ -197,6 +206,16 @@ class CliTest(TestCase):
 
 
 class CliWithRealClientTest(TestCase):
+    @patch("cuiman.cli.config.get_config")
+    def test_get_processes_configuration_error(self, mock_get_config):
+        mock_get_config.side_effect = ValueError("missing config")
+
+        runner = typer.testing.CliRunner()
+        result = runner.invoke(cli, ["list-processes"])
+
+        self.assertEqual(1, result.exit_code)
+        self.assertEqual("missing config\n", result.stderr)
+
     def test_get_processes(self):
         """Test code in app so that the non-mocked Client is used."""
         runner = typer.testing.CliRunner()

--- a/cuiman/tests/cli/test_client.py
+++ b/cuiman/tests/cli/test_client.py
@@ -7,9 +7,6 @@ from unittest import TestCase
 import pytest
 import typer
 
-# noinspection PyProtectedMember
-from typer._click import exceptions as click_exceptions
-
 from cuiman import ClientError
 from cuiman.api.client import Client
 from cuiman.api.transport import TransportError
@@ -29,7 +26,7 @@ class UseClientTest(TestCase):
 
     # noinspection PyMethodMayBeStatic
     def test_fail_with_client_error(self):
-        with pytest.raises(click_exceptions.Exit):
+        with pytest.raises(typer.Exit):
             with use_client(new_cli_context(), None):
                 raise ClientError(
                     "Not found",
@@ -59,7 +56,7 @@ class UseClientTest(TestCase):
 
     # noinspection PyMethodMayBeStatic
     def test_fail_with_transport_error(self):
-        with pytest.raises(click_exceptions.Exit):
+        with pytest.raises(typer.Exit):
             with use_client(new_cli_context(), None):
                 raise TransportError("connection could not be established")
 

--- a/cuiman/tests/cli/test_config.py
+++ b/cuiman/tests/cli/test_config.py
@@ -7,7 +7,6 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import click
 import pytest
 
 from cuiman import ClientConfig
@@ -50,7 +49,7 @@ class GetConfigTest(ConfigTestMixin, unittest.TestCase):
     # noinspection PyMethodMayBeStatic
     def test_get_config_custom(self):
         with pytest.raises(
-            click.ClickException,
+            ValueError,
             match="Configuration file fantasia.cfg not found or empty.",
         ):
             get_config("fantasia.cfg")
@@ -58,7 +57,7 @@ class GetConfigTest(ConfigTestMixin, unittest.TestCase):
     # noinspection PyMethodMayBeStatic
     def test_get_config_no_default(self):
         with pytest.raises(
-            click.ClickException,
+            ValueError,
             match=(
                 r"The client tool has not yet been configured; "
                 r"please use the 'configure' command to set it up\."

--- a/cuiman/tests/cli/test_config.py
+++ b/cuiman/tests/cli/test_config.py
@@ -88,6 +88,22 @@ class ConfigureClientWithPromptTest(ConfigTestMixin, unittest.TestCase):
         )
 
     @patch("typer.prompt")
+    def test_auth_type_invalid(self, mock_prompt: MagicMock):
+        mock_prompt.side_effect = [
+            "http://localhost:9090",
+            "torken",
+        ]
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                r"Invalid authentication type: torken\. "
+                r"Expected one of:"
+            ),
+        ):
+            configure_client_with_prompt()
+
+    @patch("typer.prompt")
     def test_auth_type_basic(self, mock_prompt: MagicMock):
         # Simulate sequential responses to typer.prompt()
         mock_prompt.side_effect = [

--- a/eozilla-airflow/pyproject.toml
+++ b/eozilla-airflow/pyproject.toml
@@ -29,7 +29,7 @@ procodile = { path = "../procodile", editable = true }
 fastapi = "*"
 pydantic = "*"
 pyyaml = "*"
-typer = "*"
+typer = ">=0.26.0"
 uvicorn = "*"
 # DAG testing
 jupyter = "*"

--- a/gavicore/pyproject.toml
+++ b/gavicore/pyproject.toml
@@ -40,10 +40,9 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-  "click",
   "pydantic",
   "pyyaml",
-  "typer",
+  "typer >=0.26.0,<1",
 ]
 
 [project.urls]

--- a/gavicore/src/gavicore/util/cli/group.py
+++ b/gavicore/src/gavicore/util/cli/group.py
@@ -2,10 +2,12 @@
 #  Permissions are hereby granted under the terms of the Apache 2.0 License:
 #  https://opensource.org/license/apache-2-0.
 
+from typing import Any, cast
+
 import typer.core
 
-# noinspection PyProtectedMember
-from typer._click import core as click_core
+
+_Command = typer.core.TyperCommand | typer.core.TyperGroup
 
 
 class AliasedGroup(typer.core.TyperGroup):
@@ -21,12 +23,12 @@ class AliasedGroup(typer.core.TyperGroup):
         return "".join(map(lambda n: n[0], name.split("-")))
 
     def get_command(
-        self, ctx: click_core.Context, cmd_name: str
-    ) -> click_core.Command | None:
+        self, ctx: Any, cmd_name: str
+    ) -> _Command | None:
         rv = super().get_command(ctx, cmd_name)
 
         if rv is not None:
-            return rv
+            return cast(_Command, rv)
 
         matches = [
             x
@@ -38,20 +40,23 @@ class AliasedGroup(typer.core.TyperGroup):
             return None
 
         if len(matches) == 1:
-            return super().get_command(ctx, matches[0])
+            return cast(_Command | None, super().get_command(ctx, matches[0]))
 
-        ctx.fail(f"Too many matches: {', '.join(sorted(matches))}")
+        raise typer.BadParameter(
+            f"Too many matches: {', '.join(sorted(matches))}",
+            param_hint="COMMAND",
+        )
 
     def resolve_command(
-        self, ctx: click_core.Context, args: list[str]
-    ) -> tuple[str | None, click_core.Command | None, list[str]]:
+        self, ctx: Any, args: list[str]
+    ) -> tuple[str | None, _Command | None, list[str]]:
         # always return the full command name
         _, cmd, args = super().resolve_command(ctx, args)
         if cmd is not None:
-            return cmd.name, cmd, args
+            return cmd.name, cast(_Command, cmd), args
         else:
             return None, None, args
 
-    def list_commands(self, ctx: click_core.Context) -> list[str]:
+    def list_commands(self, ctx: Any) -> list[str]:
         # prevent alphabetical ordering
         return list(self.commands)

--- a/gavicore/tests/util/cli/test_group.py
+++ b/gavicore/tests/util/cli/test_group.py
@@ -5,8 +5,9 @@
 import unittest
 
 import pytest
-from typer._click import core as click
+import typer
 from typer.core import TyperCommand
+from typer.testing import CliRunner
 
 from gavicore.util.cli.group import AliasedGroup
 
@@ -24,14 +25,14 @@ class AliasedGroupTest(unittest.TestCase):
         self.assert_alias_ok("test-command-b", "tcb")
 
     def test_get_command_fail(self):
-        ctx = click.Context(self.group)
-        with pytest.raises(click.UsageError):
+        ctx = typer.Context(self.group)
+        with pytest.raises(typer.BadParameter, match="Too many matches"):
             self.group.get_command(ctx, "tcc")
         self.assertIsNone(self.group.get_command(ctx, "test-command-d"))
         self.assertIsNone(self.group.get_command(ctx, "tcd"))
 
     def assert_alias_ok(self, command_name, command_alias_name):
-        ctx = click.Context(self.group)
+        ctx = typer.Context(self.group)
         command = self.group.get_command(ctx, command_name)
         self.assertIsNotNone(command)
         self.assertEqual(command_name, command.name)
@@ -40,19 +41,29 @@ class AliasedGroupTest(unittest.TestCase):
         self.assertEqual(command_name, alias_command.name)
 
     def test_resolve_command_ok(self):
-        ctx = click.Context(self.group)
+        ctx = typer.Context(self.group)
         result = self.group.resolve_command(ctx, ["tcb"])
         self.assertIsInstance(result, tuple)
         self.assertEqual(3, len(result))
         self.assertEqual("test-command-b", result[0])
-        self.assertIsInstance(result[1], click.Command)
+        self.assertIsInstance(result[1], TyperCommand)
         self.assertEqual([], result[2])
 
     def test_resolve_command_fail(self):
-        ctx = click.Context(self.group, resilient_parsing=True)
+        ctx = typer.Context(self.group, resilient_parsing=True)
         result = self.group.resolve_command(ctx, ["tcx"])
         self.assertEqual((None, None, []), result)
 
-        ctx = click.Context(self.group, resilient_parsing=False)
-        with pytest.raises(click.UsageError):
-            self.group.resolve_command(ctx, ["tcx"])
+        app = typer.Typer(cls=AliasedGroup)
+
+        @app.command("test-command")
+        def test_command():
+            pass
+
+        @app.command("other-command")
+        def other_command():
+            pass
+
+        result = CliRunner().invoke(app, ["tcx"])
+        self.assertEqual(2, result.exit_code)
+        self.assertIn("No such command", result.output)

--- a/pixi.lock
+++ b/pixi.lock
@@ -16484,19 +16484,18 @@ packages:
   - pyyaml
   - tomli-w
   - tomli ; python_full_version < '3.11'
-  - typer
+  - typer>=0.26.0,<1
   - gavicore>=0.2.0.dev0
   - procodile>=0.2.0.dev0
   requires_python: '>=3.11'
 - pypi: ./cuiman
   name: cuiman
   requires_dist:
-  - click
   - pydantic
   - pydantic-settings
   - pyyaml
   - remotestate>=0.3.1,<1
-  - typer
+  - typer>=0.26.0,<1
   - uri-template
   - httpx
   - gavicore>=0.2.0.dev0
@@ -16513,17 +16512,16 @@ packages:
 - pypi: ./gavicore
   name: gavicore
   requires_dist:
-  - click
   - pydantic
   - pyyaml
-  - typer
+  - typer>=0.26.0,<1
   requires_python: '>=3.11'
 - pypi: ./procodile
   name: procodile
   requires_dist:
   - pydantic
   - pyyaml
-  - typer
+  - typer>=0.26.0,<1
   - gavicore>=0.2.0.dev0
   requires_python: '>=3.10'
 - pypi: ./procodile-example
@@ -16535,7 +16533,7 @@ packages:
   - fastapi
   - pydantic
   - pyyaml
-  - typer
+  - typer>=0.26.0,<1
   - uvicorn
   - gavicore>=0.2.0.dev0
   - procodile>=0.2.0.dev0

--- a/procodile-example/pyproject.toml
+++ b/procodile-example/pyproject.toml
@@ -49,7 +49,7 @@ platforms = ["linux-64", "win-64"]
 
 [tool.pixi.dependencies]
 python = "3.12.*"
-typer = ">=0.16.0,<0.17"
+typer = ">=0.26.0,<1"
 pydantic = ">=2.11.7,<3"
 
 [tool.pixi.pypi-dependencies]

--- a/procodile/pyproject.toml
+++ b/procodile/pyproject.toml
@@ -42,7 +42,7 @@ requires-python = ">=3.10"
 dependencies = [
   "pydantic",
   "pyyaml",
-  "typer",
+  "typer >=0.26.0,<1",
   # local dependency
   "gavicore >=0.2.0.dev0",
 ]

--- a/procodile/src/procodile/cli/cli.py
+++ b/procodile/src/procodile/cli/cli.py
@@ -7,9 +7,6 @@ from typing import TYPE_CHECKING, Annotated, Any, Callable, Optional, Union
 
 import typer
 
-# noinspection PyProtectedMember
-from typer._click import exceptions as click_exceptions
-
 from gavicore.util.cli.group import AliasedGroup
 from gavicore.util.cli.parameters import (
     DOT_PATH_OPTION,
@@ -157,7 +154,8 @@ def new_cli(
         process_id_ = execution_request.process_id
         process = registry.get(process_id_)
         if process is None:
-            raise click_exceptions.ClickException(f"Process {process_id_!r} not found.")
+            typer.echo(f"Process {process_id_!r} not found.", err=True)
+            raise typer.Exit(code=1)
 
         job = Job.create(process, request=execution_request.to_process_request())
         job_results = job.run()
@@ -196,7 +194,8 @@ def new_cli(
         registry = _get_process_registry(ctx)
         process = registry.get(process_id)
         if process is None:
-            raise click_exceptions.ClickException(f"Process {process_id!r} not found.")
+            typer.echo(f"Process {process_id!r} not found.", err=True)
+            raise typer.Exit(code=1)
 
         typer.echo(
             json.dumps(

--- a/procodile/tests/cli/test_cli.py
+++ b/procodile/tests/cli/test_cli.py
@@ -82,7 +82,10 @@ class CliTestMixin:
     def test_execute_process_fail(self):
         result = self.invoke_cli("execute-process", "f5")
         self.assertEqual(1, result.exit_code, msg=self.get_result_msg(result))
-        self.assertIn("Process 'f5' not found.", result.output)
+        self.assertTrue(
+            "Process 'f5' not found." in result.output
+            or "Process 'f5' not found." in result.stderr
+        )
 
     def test_list_processes(self):
         result = self.invoke_cli("list-processes")
@@ -148,7 +151,10 @@ class CliTestMixin:
     def test_get_process_fail(self):
         result = self.invoke_cli("get-process", "f9")
         self.assertEqual(1, result.exit_code, msg=self.get_result_msg(result))
-        self.assertIn("Process 'f9' not found.", result.output)
+        self.assertTrue(
+            "Process 'f9' not found." in result.output
+            or "Process 'f9' not found." in result.stderr
+        )
 
     def test_help(self):
         result = self.invoke_cli("--help")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,13 +12,12 @@ platforms = ["linux-64", "win-64", "osx-64"]
 # Combined sub-workspace dependencies to prevent our editable
 # PyPI dependencies (our project's sub-workspaces) to install
 # PyPI packages instead of using conda packages.
-click = "*"
 fastapi = "*"
 httpx = "*"
 pydantic = "*"
 pydantic-settings = "*"
 pyyaml = "*"
-typer = "*"
+typer = ">=0.26.0"
 uri-template = "*"
 uvicorn = "*"
 # IDE integration

--- a/wraptile/pyproject.toml
+++ b/wraptile/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "fastapi",
   "pydantic",
   "pyyaml",
-  "typer",
+  "typer >=0.26.0,<1",
   "uvicorn",
   # local dependency
   "gavicore >=0.2.0.dev0",


### PR DESCRIPTION
We now require `typer >=0.26` and no longer depend on `click`. 
See https://typer.tiangolo.com/tutorial/click/.

Checklist (strike out non-applicable):

* [x] Changes documented in `CHANGES.md`
* [ ] ~Related issue exists and is referred to in the PR description and `CHANGES.md`~
* [ ] ~Added docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~Changes/features documented in `docs/*`~
* [x] Unit-tests adapted/added for changes/features 
* [ ] Test coverage remains or increases (target 100%)
