### PR TITLE
Fix wraptile -> Airflow auth: exchange the IdP token for an Airflow JWT

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,12 +6,14 @@
 
 - The wraptile's Airflow service now supports OAuth2 service-to-service
   authentication for the wraptile-Airflow hop, against any OIDC-compliant
-  identity provider: when `OIDC_TOKEN_URL` and `OIDC_CLIENT_ID` are set, it
-  mints a `client_credentials` token (`aud=airflow`) validated by the gateway,
-  cached and refreshed shortly before expiry. Falls back to the existing
-  username/password flow against Airflow's native token endpoint when those env
-  vars are unset. Token retrieval lives in the new
-  `wraptile.services.airflow.tokens` module.
+  identity provider. When `OIDC_TOKEN_URL` and `OIDC_CLIENT_ID` are set, it
+  performs a **two-step token exchange**: it mints a `client_credentials` token
+  at the identity provider, then exchanges it at Airflow's `/auth/token` for an
+  **Airflow-issued** JWT, which authenticates the actual API calls. The Airflow
+  JWT is cached and refreshed shortly before expiry, independently of the
+  provider token. Falls back to the existing username/password flow against
+  Airflow's native token endpoint when those env vars are unset. Token retrieval
+  lives in the new `wraptile.services.airflow.tokens` module.
 
 **Cuiman** enhancements:
 

--- a/docs/wraptile/usage.md
+++ b/docs/wraptile/usage.md
@@ -45,11 +45,13 @@ The possible options are
 
 By default, the Airflow service authenticates with a username and password
 against Airflow's own `/auth/token` endpoint (see options above, or the
-`AIRFLOW_USERNAME` / `AIRFLOW_PASSWORD` env vars).
+`AIRFLOW_USERNAME` / `AIRFLOW_PASSWORD` env vars). This suits a local Airflow
+with the simple auth manager.
 
-If a gateway is set up in front of Airflow, set these env vars to switch to
-OAuth2 client-credentials auth instead. Any OIDC-compliant identity provider
-works; only the standard token endpoint and grant are used.
+For a deployment where Airflow is configured against an identity provider
+(and typically fronted by a gateway), set these env vars instead. Any
+OIDC-compliant provider works; only the standard token endpoint and grant are
+used.
 
 * `OIDC_TOKEN_URL`: The provider's token endpoint, e.g.
   `https://idp.example/realms/eo/protocol/openid-connect/token`.
@@ -59,7 +61,29 @@ works; only the standard token endpoint and grant are used.
 * `OIDC_AUDIENCE` (optional): The `audience` sent with the token request,
   defaults to `airflow`.
 
-When `OIDC_TOKEN_URL` and `OIDC_CLIENT_ID` are both set, wraptile mints a
-`client_credentials` token (`aud=airflow`) instead of using
-`--airflow-username` / `--airflow-password`. The token is cached and refreshed
-shortly before it expires.
+When `OIDC_TOKEN_URL` and `OIDC_CLIENT_ID` are both set, wraptile stops using
+`--airflow-username` / `--airflow-password` and performs a **two-step token
+exchange** instead:
+
+1. mint a `client_credentials` token at `OIDC_TOKEN_URL`;
+2. `POST` it to Airflow's `/auth/token` (as the `Authorization` header) together
+   with the client credentials (in the body), receiving an **Airflow-issued**
+   JWT in return;
+3. use that Airflow JWT as the bearer for every API call.
+
+The Airflow JWT is cached and refreshed shortly before it expires, on its own
+schedule — the two tokens have unrelated lifetimes.
+
+> **Why two tokens, and not just the provider's?**
+> **Airflow's API accepts only tokens Airflow itself issued.** Sending the
+> provider's token as the API bearer returns `403 "Invalid JWT token"`, even
+> though Airflow is configured against that very provider — an auth manager uses
+> the provider to authenticate a *login* and to answer *authorization* queries,
+> then mints its own JWT. Airflow's own token is typically HMAC-signed with no
+> `iss` claim, which is also why a gateway cannot validate it.
+>
+> So each leg is authenticated by whichever party can actually verify it: the
+> **gateway** checks the provider token on the `/auth/token` request (this is
+> where audience and role enforcement happen), and **Airflow** checks its own JWT
+> on everything after. Without a gateway in the path the `Authorization` header
+> is simply ignored, and the same flow still works.

--- a/wraptile/src/wraptile/services/airflow/tokens.py
+++ b/wraptile/src/wraptile/services/airflow/tokens.py
@@ -19,17 +19,20 @@ two-step exchange:
 2. exchange it at Airflow's ``/auth/token`` for an **Airflow** JWT, which
    authenticates every subsequent API call.
 
-Providers, selected by :meth:`TokenConfig.create_token_provider`:
+Providers, selected by
+[`TokenConfig.create_token_provider`][wraptile.services.airflow.tokens.TokenConfig.create_token_provider]:
 
-* :class:`AirflowGatewayTokenProvider` — the two-step exchange above; the
+* [`AirflowGatewayTokenProvider`][wraptile.services.airflow.tokens.AirflowGatewayTokenProvider] — the two-step exchange above; the
   correct path whenever an IdP is configured.
-* :class:`ClientCredentialsTokenProvider` — step 1 alone. It is a *component*
+* [`ClientCredentialsTokenProvider`][wraptile.services.airflow.tokens.ClientCredentialsTokenProvider] — step 1 alone. It is a *component*
   of the exchange, not a way to talk to Airflow: its token is IdP currency.
-* :class:`AirflowNativeTokenProvider` — Airflow's ``/auth/token`` by password,
+* [`AirflowNativeTokenProvider`][wraptile.services.airflow.tokens.AirflowNativeTokenProvider] — Airflow's ``/auth/token`` by password,
   for deployments with neither an IdP nor a gateway.
 
-The environment is read in exactly one place, :meth:`TokenConfig.from_env`;
-everything downstream of it takes a :class:`TokenConfig` and is testable
+The environment is read in exactly one place,
+[`TokenConfig.from_env`][wraptile.services.airflow.tokens.TokenConfig.from_env];
+everything downstream of it takes a
+[`TokenConfig`][wraptile.services.airflow.tokens.TokenConfig] and is testable
 without touching ``os.environ``.
 
 Nothing here is specific to a particular identity provider: only the standard
@@ -189,7 +192,8 @@ class AirflowNativeTokenProvider(TokenProvider):
     correctly, disabled), and this sends no ``Authorization`` header, so a
     gateway enforcing JWT on ``/auth/token`` rejects it with 401 before Airflow
     ever sees it. When an IdP is configured, use
-    :class:`AirflowGatewayTokenProvider` instead.
+    [`AirflowGatewayTokenProvider`][wraptile.services.airflow.tokens.AirflowGatewayTokenProvider]
+    instead.
     """
 
     def __init__(self, base_url: str, username: str, password: str):
@@ -210,7 +214,9 @@ class AirflowNativeTokenProvider(TokenProvider):
 class TokenConfig:
     """Everything needed to decide *how* to obtain an Airflow bearer token.
 
-    Construct it directly in tests, or via :meth:`from_env` in production.
+    Construct it directly in tests, or via
+    [`from_env`][wraptile.services.airflow.tokens.TokenConfig.from_env] in
+    production.
     The OIDC path wins whenever it is configured; the Airflow-native path is
     the fallback.
     """
@@ -265,8 +271,10 @@ class TokenConfig:
     def create_token_provider(self) -> TokenProvider:
         """Build the token provider this configuration selects.
 
-        With OIDC configured this returns :class:`AirflowGatewayTokenProvider`,
-        never the bare :class:`ClientCredentialsTokenProvider` — the latter's
+        With OIDC configured this returns
+        [`AirflowGatewayTokenProvider`][wraptile.services.airflow.tokens.AirflowGatewayTokenProvider],
+        never the bare
+        [`ClientCredentialsTokenProvider`][wraptile.services.airflow.tokens.ClientCredentialsTokenProvider] — the latter's
         token is IdP currency, which Airflow rejects with
         ``403 "Invalid JWT token"``. The exchange is not an extra hop to be
         optimised away; it is the only thing Airflow's API accepts.

--- a/wraptile/src/wraptile/services/airflow/tokens.py
+++ b/wraptile/src/wraptile/services/airflow/tokens.py
@@ -4,20 +4,36 @@
 
 """Bearer tokens for the wraptile->airflow hop.
 
-Two ways to obtain one, selected by :meth:`TokenConfig.create_token_provider`:
+Airflow's API accepts **only tokens Airflow itself issued**. An IdP token is not
+an Airflow bearer, even when Airflow is configured against that IdP: an auth
+manager uses the IdP to authenticate a login and to answer authorization
+queries, then mints its own JWT. Sending the IdP token to ``/api/v2/*`` yields
+``403 "Invalid JWT token"``.
 
-* :class:`ClientCredentialsTokenProvider` — the OAuth2 ``client_credentials``
-  grant against any OIDC-compliant identity provider. The resulting token is
-  what the gateway in front of Airflow validates (issuer, audience, roles).
-* :class:`AirflowNativeTokenProvider` — Airflow's own ``/auth/token`` endpoint,
-  the fallback for deployments without a gateway in the path.
+So the token the *gateway* wants and the token *Airflow* wants are different,
+and both travel on the same ``Authorization`` header. The hop is therefore a
+two-step exchange:
+
+1. mint an IdP token via ``client_credentials`` — the gateway validates this
+   (issuer, audience, roles) on the ``/auth/token`` request;
+2. exchange it at Airflow's ``/auth/token`` for an **Airflow** JWT, which
+   authenticates every subsequent API call.
+
+Providers, selected by :meth:`TokenConfig.create_token_provider`:
+
+* :class:`AirflowGatewayTokenProvider` — the two-step exchange above; the
+  correct path whenever an IdP is configured.
+* :class:`ClientCredentialsTokenProvider` — step 1 alone. It is a *component*
+  of the exchange, not a way to talk to Airflow: its token is IdP currency.
+* :class:`AirflowNativeTokenProvider` — Airflow's ``/auth/token`` by password,
+  for deployments with neither an IdP nor a gateway.
 
 The environment is read in exactly one place, :meth:`TokenConfig.from_env`;
 everything downstream of it takes a :class:`TokenConfig` and is testable
 without touching ``os.environ``.
 
 Nothing here is specific to a particular identity provider: only the standard
-OAuth2 token endpoint and grant are used.
+OAuth2 token endpoint and grants are used.
 """
 
 import abc
@@ -100,8 +116,81 @@ class ClientCredentialsTokenProvider(TokenProvider):
         return self._token
 
 
+class AirflowGatewayTokenProvider(TokenProvider):
+    """Exchange an IdP service token for an Airflow-issued JWT.
+
+    Airflow's API rejects IdP tokens (``403 "Invalid JWT token"``) — it accepts
+    only JWTs it minted. Airflow's ``/auth/token`` performs the exchange, and a
+    gateway in front of it validates the IdP token on *that* request. Hence two
+    tokens, each authenticating a different leg:
+
+    * the IdP token goes on the ``Authorization`` header, satisfying the gateway;
+    * the client credentials go in the body, satisfying Airflow.
+
+    Both are needed simultaneously. Without a gateway the header is simply
+    ignored, so this provider is also correct when Airflow is reached directly.
+
+    The Airflow JWT is cached against **its own** expiry, which is unrelated to
+    the IdP token's: ``inner`` re-mints independently on its own schedule.
+    Deriving one lifetime from the other silently breaks the hop the moment the
+    shorter one lapses.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        client_id: str,
+        client_secret: Optional[str],
+        inner: TokenProvider,
+    ):
+        self._base_url = base_url
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._inner = inner
+        self._token: Optional[str] = None
+        self._expiry: float = 0.0
+
+    def get_token(self) -> str:
+        now = time.monotonic()
+        if self._token and now < self._expiry:
+            return self._token
+
+        body = {"grant_type": "client_credentials", "client_id": self._client_id}
+        if self._client_secret:
+            body["client_secret"] = self._client_secret
+
+        response = requests.post(
+            f"{self._base_url}/auth/token",
+            json=body,
+            # The IdP token authenticates this request to the gateway, not to
+            # Airflow; Airflow authenticates it from the body above.
+            headers={"Authorization": f"Bearer {self._inner.get_token()}"},
+            timeout=TOKEN_REQUEST_TIMEOUT,
+        )
+        token_data = _json_or_raise(response)
+        self._token = token_data["access_token"]
+        # Airflow's response carries no "expires_in"; its lifetime comes from
+        # the server's api_auth.jwt_expiration_time. Assume the conservative
+        # default and re-mint early — an over-eager exchange costs one request,
+        # a stale JWT costs a 403 mid-flight.
+        self._expiry = (
+            now
+            + token_data.get("expires_in", DEFAULT_TOKEN_LIFETIME)
+            - TOKEN_REFRESH_MARGIN
+        )
+        return self._token
+
+
 class AirflowNativeTokenProvider(TokenProvider):
-    """Airflow's own ``/auth/token`` endpoint, authenticated by password."""
+    """Airflow's own ``/auth/token`` endpoint, authenticated by password.
+
+    Only for deployments with **no IdP and no gateway**: the password grant
+    requires direct access grants enabled on the IdP client (normally, and
+    correctly, disabled), and this sends no ``Authorization`` header, so a
+    gateway enforcing JWT on ``/auth/token`` rejects it with 401 before Airflow
+    ever sees it. When an IdP is configured, use
+    :class:`AirflowGatewayTokenProvider` instead.
+    """
 
     def __init__(self, base_url: str, username: str, password: str):
         self._base_url = base_url
@@ -176,6 +265,12 @@ class TokenConfig:
     def create_token_provider(self) -> TokenProvider:
         """Build the token provider this configuration selects.
 
+        With OIDC configured this returns :class:`AirflowGatewayTokenProvider`,
+        never the bare :class:`ClientCredentialsTokenProvider` — the latter's
+        token is IdP currency, which Airflow rejects with
+        ``403 "Invalid JWT token"``. The exchange is not an extra hop to be
+        optimised away; it is the only thing Airflow's API accepts.
+
         Raises:
             RuntimeError: If the OIDC settings are only half-filled, or if the
                 native fallback has no Airflow password.
@@ -189,11 +284,16 @@ class TokenConfig:
                     "incomplete OIDC configuration; please set both env vars"
                     " OIDC_TOKEN_URL and OIDC_CLIENT_ID"
                 )
-            return ClientCredentialsTokenProvider(
-                token_url=self.oidc_token_url,
+            return AirflowGatewayTokenProvider(
+                self.airflow_base_url,
                 client_id=self.oidc_client_id,
                 client_secret=self.oidc_client_secret,
-                audience=self.oidc_audience,
+                inner=ClientCredentialsTokenProvider(
+                    token_url=self.oidc_token_url,
+                    client_id=self.oidc_client_id,
+                    client_secret=self.oidc_client_secret,
+                    audience=self.oidc_audience,
+                ),
             )
 
         if not self.airflow_password:

--- a/wraptile/tests/services/airflow/test_tokens.py
+++ b/wraptile/tests/services/airflow/test_tokens.py
@@ -9,9 +9,11 @@ import requests
 
 from wraptile.exceptions import ServiceException
 from wraptile.services.airflow.tokens import (
+    AirflowGatewayTokenProvider,
     AirflowNativeTokenProvider,
     ClientCredentialsTokenProvider,
     TokenConfig,
+    TokenProvider,
     create_token_provider,
 )
 
@@ -89,6 +91,117 @@ class ClientCredentialsTokenProviderTest(TestCase):
         self.assertEqual(ctx.exception.status_code, 401)
 
 
+class _StubTokenProvider(TokenProvider):
+    """Stands in for the IdP leg so the exchange can be tested on its own."""
+
+    def __init__(self, token: str = "idp-token"):  # noqa: S107
+        self.token = token
+        self.calls = 0
+
+    def get_token(self) -> str:
+        self.calls += 1
+        return self.token
+
+
+class AirflowGatewayTokenProviderTest(TestCase):
+    def _provider(self, inner=None):
+        return AirflowGatewayTokenProvider(
+            "http://airflow:8080",
+            client_id="wraptile",
+            client_secret="s3cr3t",  # noqa: S106
+            inner=inner or _StubTokenProvider(),
+        )
+
+    @patch("wraptile.services.airflow.tokens.requests.post")
+    def test_exchanges_idp_token_for_airflow_jwt(self, mock_post):
+        mock_post.return_value = _token_response("airflow-jwt")
+
+        self.assertEqual(self._provider().get_token(), "airflow-jwt")
+
+        args, kwargs = mock_post.call_args
+        self.assertEqual(args[0], "http://airflow:8080/auth/token")
+        # The IdP token authenticates the request to the gateway...
+        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer idp-token")
+        # ...and the client credentials authenticate it to Airflow. Both legs,
+        # one request: dropping either one breaks the hop.
+        self.assertEqual(
+            kwargs["json"],
+            {
+                "grant_type": "client_credentials",
+                "client_id": "wraptile",
+                "client_secret": "s3cr3t",
+            },
+        )
+
+    @patch("wraptile.services.airflow.tokens.requests.post")
+    def test_returns_airflow_jwt_not_the_idp_token(self, mock_post):
+        # The bug this whole provider exists to prevent: handing Airflow the IdP
+        # token yields 403 "Invalid JWT token" on every API call.
+        mock_post.return_value = _token_response("airflow-jwt")
+        inner = _StubTokenProvider("idp-token")
+
+        token = self._provider(inner).get_token()
+
+        self.assertEqual(token, "airflow-jwt")
+        self.assertNotEqual(token, inner.token)
+
+    @patch("wraptile.services.airflow.tokens.requests.post")
+    def test_caches_the_airflow_jwt(self, mock_post):
+        mock_post.return_value = _token_response("airflow-jwt")
+        provider = self._provider()
+
+        self.assertEqual(provider.get_token(), "airflow-jwt")
+        self.assertEqual(provider.get_token(), "airflow-jwt")
+        mock_post.assert_called_once()
+
+    @patch("wraptile.services.airflow.tokens.requests.post")
+    def test_re_exchanges_when_the_airflow_jwt_expires(self, mock_post):
+        mock_post.side_effect = [_token_response("first"), _token_response("second")]
+        provider = self._provider()
+
+        self.assertEqual(provider.get_token(), "first")
+        provider._expiry = 0.0
+        self.assertEqual(provider.get_token(), "second")
+        self.assertEqual(mock_post.call_count, 2)
+
+    @patch("wraptile.services.airflow.tokens.requests.post")
+    def test_idp_token_lifetime_is_independent_of_the_airflow_jwt(self, mock_post):
+        # The two tokens expire on unrelated schedules. The inner provider does
+        # its own caching, so the exchange must re-ask it every time rather than
+        # pinning the IdP token to the Airflow JWT's lifetime.
+        mock_post.side_effect = [_token_response("first"), _token_response("second")]
+        inner = _StubTokenProvider()
+        provider = self._provider(inner)
+
+        provider.get_token()
+        provider._expiry = 0.0
+        provider.get_token()
+
+        self.assertEqual(inner.calls, 2)
+
+    @patch("wraptile.services.airflow.tokens.requests.post")
+    def test_omits_secret_for_a_public_client(self, mock_post):
+        mock_post.return_value = _token_response()
+        AirflowGatewayTokenProvider(
+            "http://airflow:8080",
+            client_id="public-client",
+            client_secret=None,
+            inner=_StubTokenProvider(),
+        ).get_token()
+
+        self.assertNotIn("client_secret", mock_post.call_args.kwargs["json"])
+
+    @patch("wraptile.services.airflow.tokens.requests.post")
+    def test_http_error_becomes_service_exception(self, mock_post):
+        response = MagicMock(status_code=403, reason="Forbidden")
+        response.raise_for_status.side_effect = requests.exceptions.HTTPError("nope")
+        mock_post.return_value = response
+
+        with self.assertRaises(ServiceException) as ctx:
+            self._provider().get_token()
+        self.assertEqual(ctx.exception.status_code, 403)
+
+
 class AirflowNativeTokenProviderTest(TestCase):
     @patch("wraptile.services.airflow.tokens.requests.post")
     def test_posts_credentials_to_auth_token(self, mock_post):
@@ -147,14 +260,19 @@ class TokenConfigFromEnvTest(TestCase):
 
 
 class CreateTokenProviderTest(TestCase):
-    def test_client_credentials_selected_when_configured(self):
+    def test_oidc_selects_the_exchange_not_the_bare_idp_token(self):
+        # Returning ClientCredentialsTokenProvider here would send Airflow an
+        # IdP token, which it rejects with 403 on every call. The bare provider
+        # is only ever the inner leg of the exchange.
         provider = TokenConfig(
             airflow_base_url="http://airflow:8080",
             oidc_token_url=_OIDC_ENV["OIDC_TOKEN_URL"],
             oidc_client_id="wraptile",
         ).create_token_provider()
-        self.assertIsInstance(provider, ClientCredentialsTokenProvider)
-        self.assertEqual(provider._audience, "airflow")
+        self.assertIsInstance(provider, AirflowGatewayTokenProvider)
+        self.assertIsInstance(provider._inner, ClientCredentialsTokenProvider)
+        self.assertEqual(provider._inner._audience, "airflow")
+        self.assertEqual(provider._base_url, "http://airflow:8080")
 
     def test_falls_back_to_native_provider(self):
         provider = TokenConfig(
@@ -184,4 +302,4 @@ class CreateTokenProviderTest(TestCase):
     @patch.dict("os.environ", _OIDC_ENV, clear=True)
     def test_module_function_reads_the_environment(self):
         provider = create_token_provider("http://airflow:8080")
-        self.assertIsInstance(provider, ClientCredentialsTokenProvider)
+        self.assertIsInstance(provider, AirflowGatewayTokenProvider)


### PR DESCRIPTION
  Wraptile's `keycloak` auth mode didn't work against a real Airflow deployed instance. It minted a                                                                                                                                         
  Keycloak `client_credentials` token and sent it as the Airflow API bearer, which                                                                                                                                         
  Airflow rejects with `403 "Invalid JWT token"` on every call.
  **Root cause:** Airflow's API accepts only tokens Airflow itself issued.

This PR implements a **two-step exchange**, using the `client_credentials` grant that                                                                                                                                                 
  `apache-airflow-providers-keycloak` exposes on Airflow's own `/auth/token`:                                                                                                                                              
                                                                                                                                                                                                                           
  1. mint a `client_credentials` token at the IdP , satisfies the **gateway**;                                                                                                                                             
  2. POST it to Airflow's `/auth/token` (token on the `Authorization` header,                                                                                                                                              
     client credentials in the body) -> **Airflow-issued JWT**;                                                                                                                                                             
  3. use that JWT for every API call. 
  


Checklist (strike out non-applicable):

* [x] Changes documented in `CHANGES.md`
* [ ] ~~Related issue exists and is referred to in the PR description and `CHANGES.md`~~
* [x] Added docstrings and API docs for any new/modified user-facing classes and functions
* [x] Changes/features documented in `docs/*`
* [x] Unit-tests adapted/added for changes/features 
* [x] Test coverage remains or increases (target 100%)
