### PR TITLE
fix failing local tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,13 @@
   - Updated `notebooks/cuiman-gui.ipynb` to demonstrate new app-based GUI.
   - Added package `cuiman.app` that implements the new app-based GUI.
 
+### Fixes
+
+- Fixed test isolation in `cuiman`'s client tests: the default-transport tests
+  no longer read the developer's real `~/.eozilla/config`, which could inject a
+  logged-in token into the request headers and fail the assertion that an
+  unauthenticated client sends none. (#167)
+
 ### Other changes
 
 - We require `typer >=0.26` and no longer depend on `click`. 

--- a/cuiman/tests/api/test_async_client.py
+++ b/cuiman/tests/api/test_async_client.py
@@ -2,6 +2,7 @@
 #  Permissions are hereby granted under the terms of the Apache 2.0 License:
 #  https://opensource.org/license/apache-2-0.
 
+import os
 from pathlib import Path
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, patch
@@ -81,8 +82,9 @@ class AsyncClientTest(IsolatedAsyncioTestCase):
             patch.object(ClientConfig, "return_type_map", return_type_map),
             # Isolate from any real ~/.eozilla/config on the developer's machine,
             # which would otherwise inject a logged-in token into the headers.
+            # os.devnull is not a directory, so this path can never exist.
             patch.object(
-                ClientConfig, "default_path", Path("/nonexistent/.eozilla/config")
+                ClientConfig, "default_path", Path(os.devnull, ".eozilla", "config")
             ),
             patch("cuiman.api.async_client.HttpxTransport") as httpx_transport_cls,
         ):

--- a/cuiman/tests/api/test_async_client.py
+++ b/cuiman/tests/api/test_async_client.py
@@ -2,6 +2,7 @@
 #  Permissions are hereby granted under the terms of the Apache 2.0 License:
 #  https://opensource.org/license/apache-2-0.
 
+from pathlib import Path
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, patch
 
@@ -78,6 +79,11 @@ class AsyncClientTest(IsolatedAsyncioTestCase):
         return_type_map = {JobInfo: dict}
         with (
             patch.object(ClientConfig, "return_type_map", return_type_map),
+            # Isolate from any real ~/.eozilla/config on the developer's machine,
+            # which would otherwise inject a logged-in token into the headers.
+            patch.object(
+                ClientConfig, "default_path", Path("/nonexistent/.eozilla/config")
+            ),
             patch("cuiman.api.async_client.HttpxTransport") as httpx_transport_cls,
         ):
             transport = httpx_transport_cls.return_value

--- a/cuiman/tests/api/test_client.py
+++ b/cuiman/tests/api/test_client.py
@@ -2,6 +2,7 @@
 #  Permissions are hereby granted under the terms of the Apache 2.0 License:
 #  https://opensource.org/license/apache-2-0.
 
+from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -73,6 +74,11 @@ class ClientTest(TestCase):
         return_type_map = {JobInfo: dict}
         with (
             patch.object(ClientConfig, "return_type_map", return_type_map),
+            # Isolate from any real ~/.eozilla/config on the developer's machine,
+            # which would otherwise inject a logged-in token into the headers.
+            patch.object(
+                ClientConfig, "default_path", Path("/nonexistent/.eozilla/config")
+            ),
             patch("cuiman.api.client.HttpxTransport") as httpx_transport_cls,
         ):
             transport = httpx_transport_cls.return_value

--- a/cuiman/tests/api/test_client.py
+++ b/cuiman/tests/api/test_client.py
@@ -2,6 +2,7 @@
 #  Permissions are hereby granted under the terms of the Apache 2.0 License:
 #  https://opensource.org/license/apache-2-0.
 
+import os
 from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
@@ -76,8 +77,9 @@ class ClientTest(TestCase):
             patch.object(ClientConfig, "return_type_map", return_type_map),
             # Isolate from any real ~/.eozilla/config on the developer's machine,
             # which would otherwise inject a logged-in token into the headers.
+            # os.devnull is not a directory, so this path can never exist.
             patch.object(
-                ClientConfig, "default_path", Path("/nonexistent/.eozilla/config")
+                ClientConfig, "default_path", Path(os.devnull, ".eozilla", "config")
             ),
             patch("cuiman.api.client.HttpxTransport") as httpx_transport_cls,
         ):


### PR DESCRIPTION
  The two failures were a test-isolation leak: Client/AsyncClient built with no config_path fall back to ClientConfig.default_path (~/.eozilla/config), and user machine has a real logged-in config there with a live JWT, so auth_headers returned a Bearer header instead of {}. CI passes only because it has no such file.

closes #167 

Checklist (strike out non-applicable):

* [x] Changes documented in `CHANGES.md`
* [x] Related issue exists and is referred to in the PR description and `CHANGES.md`
* [ ] Added docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes/features documented in `docs/*`
* [x] Unit-tests adapted/added for changes/features 
* [x] Test coverage remains or increases (target 100%)
