### PR TITLE
Set job status to dismissed in case the dismiss endpoint is called (close #174)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,10 @@
   no longer read the developer's real `~/.eozilla/config`, which could inject a
   logged-in token into the request headers and fail the assertion that an
   unauthenticated client sends none. (#167)
+- Successful dismissal of jobs via a DELETE request to the `/jobs/{jobID}`
+  endpoint returns a `JobInfo` object whose `status` field is always set
+  to "dismissed" as per requirement `/req/dismiss/job-dismiss-success`
+  of the OGC API - Processes - Part 1: Core specification. (#174)
 
 ### Other changes
 

--- a/wraptile/src/wraptile/services/airflow/airflow_service.py
+++ b/wraptile/src/wraptile/services/airflow/airflow_service.py
@@ -228,7 +228,9 @@ class AirflowService(ServiceBase):
             raise ServiceException(
                 e.status, e.reason, exception=e, is_job_problem=True
             ) from e
-        return self.dag_run_to_job_info(dag_run)
+        job_info: JobInfo = self.dag_run_to_job_info(dag_run)
+        job_info.status = JobStatus.dismissed
+        return job_info
 
     async def get_job_results(self, job_id: str, *args, **kwargs) -> JobResults:
         dag_id = self.get_dag_id_from_job_id(job_id)

--- a/wraptile/src/wraptile/services/local/local_service.py
+++ b/wraptile/src/wraptile/services/local/local_service.py
@@ -162,6 +162,7 @@ class LocalService(ServiceBase):
             del self.jobs[job_id]
             self.job_results.pop(job_id, None)
             self.job_uses_processes.pop(job_id, None)
+        job.job_info.status = JobStatus.dismissed
         return job.job_info
 
     async def get_job_results(self, job_id: str, *args, **_kwargs) -> JobResults:

--- a/wraptile/tests/services/local/test_local_service.py
+++ b/wraptile/tests/services/local/test_local_service.py
@@ -240,11 +240,26 @@ class LocalServiceTest(IsolatedAsyncioTestCase):
         job_info = await self.service.dismiss_job(
             job_id=job_info.jobID, request=self.get_request()
         )
-        self.assertIn(
-            job_info.status,
-            {JobStatus.accepted, JobStatus.running, JobStatus.dismissed},
-        )
+        self.assertEqual(job_info.status, JobStatus.dismissed)
         self.assertTrue(self.service.jobs[job_info.jobID].cancelled)
+
+    async def test_dismiss_running_job_leaves_entry(self):
+        job_info = await self.service.execute_process(
+            process_id="sleep_a_while",
+            process_request=ProcessRequest(inputs={"duration": 0.5}),
+            request=self.get_request(),
+        )
+        job_info = await self.service.dismiss_job(
+            job_id=job_info.jobID, request=self.get_request()
+        )
+        queried_job = await self.service.get_job(
+            job_info.jobID, request=self.get_request()
+        )
+        self.assertIsInstance(queried_job, JobInfo)
+        self.assertEqual(job_info.status, JobStatus.dismissed)
+        self.assertEqual(queried_job.status, JobStatus.dismissed)
+        self.assertEqual("sleep_a_while", queried_job.processID)
+        self.assertEqual(job_info.jobID, queried_job.jobID)
 
     async def test_dismiss_finished_job_removes_cached_state(self):
         job_info = await self.service.execute_process(


### PR DESCRIPTION
[Description of PR]

Explicitly set the `status` field for both the local backend and the airflow backend

Checklist (strike out non-applicable):

* [x] Changes documented in `CHANGES.md`
* [x] Related issue exists and is referred to in the PR description and `CHANGES.md`
~* [ ] Added docstrings and API docs for any new/modified user-facing classes and functions~
~* [ ] Changes/features documented in `docs/*`~
* [x] Unit-tests adapted/added for changes/features
* [x] Test coverage remains or increases (target 100%)
