### PR TITLE
Support CORS in cuiman's app server

### DIFF
--- a/cuiman/pyproject.toml
+++ b/cuiman/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "pydantic",
   "pydantic-settings",
   "pyyaml",
-  "remotestate >=0.3.1,<1",
+  "remotestate >=0.3.4.dev1,<1",
   "typer >=0.26.0,<1",
   "uri-template",
   "httpx",

--- a/cuiman/src/cuiman/app/serve.py
+++ b/cuiman/src/cuiman/app/serve.py
@@ -74,6 +74,7 @@ def serve(
         rs.Service(store),
         ui_dist=app_dist,
         host="127.0.0.1",
+        cors_origins=["*"],
         display="none",
     )
 

--- a/cuiman/tests/app/test_serve.py
+++ b/cuiman/tests/app/test_serve.py
@@ -55,6 +55,7 @@ def test_serve_returns_server_without_display(monkeypatch):
             "ui_dist": "https://app.example.test",
             "host": "127.0.0.1",
             "display": "none",
+            "cors_origins": ["*"],
         }
     ]
     assert calls["url"] == []
@@ -81,6 +82,7 @@ def test_serve_opens_browser(monkeypatch):
             "ui_dist": "https://app.example.test",
             "host": "127.0.0.1",
             "display": "none",
+            "cors_origins": ["*"],
         }
     ]
     assert calls["url"][0]["base_url"] == "http://127.0.0.1:8765"

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,8 +1,20 @@
 version: 7
 platforms:
 - name: linux-64
+  virtual-packages:
+  - __unix=0=0
+  - __linux=4.18
+  - __glibc=2.28
+  - __archspec=0=x86_64
 - name: osx-64
+  virtual-packages:
+  - __unix=0=0
+  - __osx=13.0
+  - __archspec=0=x86_64
 - name: win-64
+  virtual-packages:
+  - __win=10.0
+  - __archspec=0=x86_64
 environments:
   default:
     channels:
@@ -508,9 +520,9 @@ environments:
       - pypi: ./wraptile
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1a/4b/6fd6dd632019b7f522f1b1f794ab6115cd79890330986614be56fd18f0eb/mkdocs_mermaid2_plugin-1.2.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1a/8b/b884fc91f05bb32b57c3149df39d67e4b7f25ca7d4403413ab1ef101581c/remotestate-0.3.4.dev1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/51/0b/607e06204b207c29a86759c763624aabbdd16613844564536847d71ad461/jsbeautifier-2.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/53/c7/d168dd2e2120b1a61ffdcf6eaa6d992620a793d3bf7e12a59704eda1d83b/apache_airflow_client-3.0.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/80/a0/7bb35512648162276acc1c8e43fa8e456a3da15f54878eb9e392e056b4a3/remotestate-0.3.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/fd/a40c621ff207f3ce8e484aa0fc8ba4eb6e3ecf52e15b42ba764b457a9550/editorconfig-0.17.1-py3-none-any.whl
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
@@ -973,9 +985,9 @@ environments:
       - pypi: ./wraptile
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1a/4b/6fd6dd632019b7f522f1b1f794ab6115cd79890330986614be56fd18f0eb/mkdocs_mermaid2_plugin-1.2.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1a/8b/b884fc91f05bb32b57c3149df39d67e4b7f25ca7d4403413ab1ef101581c/remotestate-0.3.4.dev1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/51/0b/607e06204b207c29a86759c763624aabbdd16613844564536847d71ad461/jsbeautifier-2.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/53/c7/d168dd2e2120b1a61ffdcf6eaa6d992620a793d3bf7e12a59704eda1d83b/apache_airflow_client-3.0.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/80/a0/7bb35512648162276acc1c8e43fa8e456a3da15f54878eb9e392e056b4a3/remotestate-0.3.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/fd/a40c621ff207f3ce8e484aa0fc8ba4eb6e3ecf52e15b42ba764b457a9550/editorconfig-0.17.1-py3-none-any.whl
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
@@ -1438,9 +1450,9 @@ environments:
       - pypi: ./wraptile
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1a/4b/6fd6dd632019b7f522f1b1f794ab6115cd79890330986614be56fd18f0eb/mkdocs_mermaid2_plugin-1.2.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1a/8b/b884fc91f05bb32b57c3149df39d67e4b7f25ca7d4403413ab1ef101581c/remotestate-0.3.4.dev1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/51/0b/607e06204b207c29a86759c763624aabbdd16613844564536847d71ad461/jsbeautifier-2.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/53/c7/d168dd2e2120b1a61ffdcf6eaa6d992620a793d3bf7e12a59704eda1d83b/apache_airflow_client-3.0.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/80/a0/7bb35512648162276acc1c8e43fa8e456a3da15f54878eb9e392e056b4a3/remotestate-0.3.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/fd/a40c621ff207f3ce8e484aa0fc8ba4eb6e3ecf52e15b42ba764b457a9550/editorconfig-0.17.1-py3-none-any.whl
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -2000,7 +2012,7 @@ packages:
   - python_abi 3.14.* *_cp314
   license: MIT
   purls:
-  - pkg:pypi/cffi?source=hash-mapping
+  - pkg:pypi/cffi?source=compressed-mapping
   run_exports: {}
   size: 306297
   timestamp: 1783424159025
@@ -2115,7 +2127,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/debugpy?source=compressed-mapping
+  - pkg:pypi/debugpy?source=hash-mapping
   run_exports: {}
   size: 2842115
   timestamp: 1780390153580
@@ -4242,7 +4254,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/nh3?source=compressed-mapping
+  - pkg:pypi/nh3?source=hash-mapping
   run_exports: {}
   size: 672346
   timestamp: 1782129862714
@@ -4496,7 +4508,7 @@ packages:
   - tk >=8.6.13,<8.7.0a0
   license: HPND
   purls:
-  - pkg:pypi/pillow?source=compressed-mapping
+  - pkg:pypi/pillow?source=hash-mapping
   run_exports: {}
   size: 1108174
   timestamp: 1782912080163
@@ -5008,7 +5020,7 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/tornado?source=compressed-mapping
+  - pkg:pypi/tornado?source=hash-mapping
   run_exports: {}
   size: 918368
   timestamp: 1781006801436
@@ -5145,7 +5157,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=compressed-mapping
+  - pkg:pypi/wrapt?source=hash-mapping
   run_exports: {}
   size: 118096
   timestamp: 1782133651496
@@ -5833,8 +5845,7 @@ packages:
   depends:
   - python >=3.14
   license: BSD-3-Clause AND MIT AND EPL-2.0
-  purls:
-  - pkg:pypi/backports-zstd?source=compressed-mapping
+  purls: []
   run_exports: {}
   size: 7526
   timestamp: 1781450817767
@@ -5861,7 +5872,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/beautifulsoup4?source=hash-mapping
+  - pkg:pypi/beautifulsoup4?source=compressed-mapping
   run_exports: {}
   size: 92704
   timestamp: 1780853175566
@@ -6153,7 +6164,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/dask?source=compressed-mapping
+  - pkg:pypi/dask?source=hash-mapping
   run_exports: {}
   size: 1074754
   timestamp: 1783370469246
@@ -6372,8 +6383,7 @@ packages:
   - uvicorn-standard
   license: MIT
   license_family: MIT
-  purls:
-  - pkg:pypi/fastapi?source=compressed-mapping
+  purls: []
   run_exports: {}
   size: 4836
   timestamp: 1782997724066
@@ -6417,7 +6427,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/fastapi?source=compressed-mapping
+  - pkg:pypi/fastapi?source=hash-mapping
   run_exports: {}
   size: 103957
   timestamp: 1782997724066
@@ -6566,8 +6576,7 @@ packages:
   - xyzservices
   license: BSD-3-Clause
   license_family: BSD
-  purls:
-  - pkg:pypi/geopandas?source=compressed-mapping
+  purls: []
   run_exports: {}
   size: 8267
   timestamp: 1782507446937
@@ -6583,7 +6592,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/geopandas?source=compressed-mapping
+  - pkg:pypi/geopandas?source=hash-mapping
   run_exports: {}
   size: 255909
   timestamp: 1782507445933
@@ -7316,7 +7325,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/jupyter-client?source=compressed-mapping
+  - pkg:pypi/jupyter-client?source=hash-mapping
   run_exports: {}
   size: 117954
   timestamp: 1781019994076
@@ -8508,7 +8517,7 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/pytest-asyncio?source=compressed-mapping
+  - pkg:pypi/pytest-asyncio?source=hash-mapping
   run_exports: {}
   size: 43101
   timestamp: 1779802443053
@@ -8614,7 +8623,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/python-json-logger?source=compressed-mapping
+  - pkg:pypi/python-json-logger?source=hash-mapping
   run_exports: {}
   size: 19249
   timestamp: 1781036004580
@@ -9133,7 +9142,7 @@ packages:
   - ipywidgets >=6.0
   license: MPL-2.0 and MIT
   purls:
-  - pkg:pypi/tqdm?source=compressed-mapping
+  - pkg:pypi/tqdm?source=hash-mapping
   run_exports: {}
   size: 681697
   timestamp: 1783440211093
@@ -9150,7 +9159,7 @@ packages:
   - ipywidgets >=6.0
   license: MPL-2.0 and MIT
   purls:
-  - pkg:pypi/tqdm?source=compressed-mapping
+  - pkg:pypi/tqdm?source=hash-mapping
   run_exports: {}
   size: 681392
   timestamp: 1783440259840
@@ -9411,7 +9420,7 @@ packages:
   - python
   license: MIT
   purls:
-  - pkg:pypi/virtualenv?source=compressed-mapping
+  - pkg:pypi/virtualenv?source=hash-mapping
   run_exports: {}
   size: 3272894
   timestamp: 1783424056921
@@ -11864,7 +11873,7 @@ packages:
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/matplotlib?source=hash-mapping
+  - pkg:pypi/matplotlib?source=compressed-mapping
   run_exports: {}
   size: 8988367
   timestamp: 1782829965885
@@ -12472,7 +12481,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pyzmq?source=hash-mapping
+  - pkg:pypi/pyzmq?source=compressed-mapping
   run_exports: {}
   size: 192531
   timestamp: 1779484028794
@@ -12974,7 +12983,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/ast-serialize?source=compressed-mapping
+  - pkg:pypi/ast-serialize?source=hash-mapping
   run_exports: {}
   size: 1075388
   timestamp: 1782863865593
@@ -15210,7 +15219,7 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/msgpack?source=hash-mapping
+  - pkg:pypi/msgpack?source=compressed-mapping
   run_exports: {}
   size: 89771
   timestamp: 1782460807585
@@ -15764,7 +15773,7 @@ packages:
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/pywin32?source=compressed-mapping
+  - pkg:pypi/pywin32?source=hash-mapping
   run_exports: {}
   size: 4472831
   timestamp: 1781362876741
@@ -15830,7 +15839,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pyzmq?source=hash-mapping
+  - pkg:pypi/pyzmq?source=compressed-mapping
   run_exports: {}
   size: 182831
   timestamp: 1779483925948
@@ -15948,8 +15957,7 @@ packages:
   - vc14_runtime >=14.44.35208
   license: BSD-3-Clause
   license_family: BSD
-  purls:
-  - pkg:pypi/scipy?source=compressed-mapping
+  purls: []
   run_exports: {}
   size: 15353018
   timestamp: 1781914001107
@@ -16045,7 +16053,7 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/tornado?source=compressed-mapping
+  - pkg:pypi/tornado?source=hash-mapping
   run_exports: {}
   size: 919275
   timestamp: 1781006902968
@@ -16223,7 +16231,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=compressed-mapping
+  - pkg:pypi/wrapt?source=hash-mapping
   run_exports: {}
   size: 115544
   timestamp: 1782133735742
@@ -16494,7 +16502,7 @@ packages:
   - pydantic
   - pydantic-settings
   - pyyaml
-  - remotestate>=0.3.1,<1
+  - remotestate>=0.3.4.dev1,<1
   - typer>=0.26.0,<1
   - uri-template
   - httpx
@@ -16569,6 +16577,15 @@ packages:
   - packaging ; extra == 'test'
   - requests-html ; extra == 'test'
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/1a/8b/b884fc91f05bb32b57c3149df39d67e4b7f25ca7d4403413ab1ef101581c/remotestate-0.3.4.dev1-py3-none-any.whl
+  name: remotestate
+  version: 0.3.4.dev1
+  sha256: fc96523bf30c815ce3b90214f45ee43c3bcdeef64754c9f5a9d139054b82c72a
+  requires_dist:
+  - fastapi>=0.136,<1
+  - pydantic>=2,<3
+  - uvicorn>=0.46,<1
+  requires_python: '>=3.12'
 - pypi: https://files.pythonhosted.org/packages/51/0b/607e06204b207c29a86759c763624aabbdd16613844564536847d71ad461/jsbeautifier-2.0.3-py3-none-any.whl
   name: jsbeautifier
   version: 2.0.3
@@ -16584,15 +16601,6 @@ packages:
   - python-dateutil
   - urllib3>=2.1.0
   requires_python: ~=3.9
-- pypi: https://files.pythonhosted.org/packages/80/a0/7bb35512648162276acc1c8e43fa8e456a3da15f54878eb9e392e056b4a3/remotestate-0.3.3-py3-none-any.whl
-  name: remotestate
-  version: 0.3.3
-  sha256: eabd192a868f89d90313c7f371d91d5d053b11ff7267f6460afbbe71ba6e621b
-  requires_dist:
-  - fastapi>=0.136,<1
-  - pydantic>=2,<3
-  - uvicorn>=0.46,<1
-  requires_python: '>=3.12'
 - pypi: https://files.pythonhosted.org/packages/96/fd/a40c621ff207f3ce8e484aa0fc8ba4eb6e3ecf52e15b42ba764b457a9550/editorconfig-0.17.1-py3-none-any.whl
   name: editorconfig
   version: 0.17.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ procodile = { path = "./procodile", editable = true }
 procodile-example = { path = "./procodile-example", editable = true }
 wraptile = { path = "./wraptile", editable = true }
 # Cuiman GUI
-remotestate = ">=0.3.3,<1"
+remotestate = ">=0.3.4.dev1,<1"
 # remotestate = { path = "../remotestate/remotestate-py", editable = true }
 # Airflow is only available on PyPI
 apache-airflow-client = "==3.0.2"


### PR DESCRIPTION
Supports CORS in cuiman's app server, by using `remotestate 0.3.4.dev1`, which now allows to do so.
See https://github.com/bcdev/remotestate/pull/50

Checklist (strike out non-applicable):

* [ ] Changes documented in `CHANGES.md`
* [ ] Related issue exists and is referred to in the PR description and `CHANGES.md`
* [ ] Added docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes/features documented in `docs/*`
* [x] Unit-tests adapted/added for changes/features 
* [x] Test coverage remains or increases (target 100%)
